### PR TITLE
Feat: 포스트 검색 기능 추가 (Fuse.js 클라이언트 사이드 정적 검색)

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -18,6 +18,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.13",
+    "fuse.js": "^7.4.2",
     "next": "^16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/apps/blog/src/app/(main)/main-client-layout.tsx
+++ b/apps/blog/src/app/(main)/main-client-layout.tsx
@@ -2,6 +2,7 @@
 
 import { MainFooter } from '@components/main-footer';
 import { MainHeader } from '@components/main-header';
+import { SearchModal, SearchProvider } from '@components/search';
 import { PostModel, SeriesModel, TagModel } from '@libs/types/commons';
 import { createContext, PropsWithChildren, useMemo } from 'react';
 
@@ -40,22 +41,28 @@ export default function MainClientLayout({
 
   return (
     <MainLayoutContext.Provider value={contextState}>
-      <div className="blog-main-layout h-full">
-        {/* ------------------------------------------------------ */}
-        {/* HEADER */}
-        {/* ------------------------------------------------------ */}
-        <MainHeader seriesList={seriesList} tags={tags} />
+      {/* 검색 컨텍스트로 헤더 버튼과 모달이 상태를 공유한다 */}
+      <SearchProvider>
+        <div className="blog-main-layout h-full">
+          {/* ------------------------------------------------------ */}
+          {/* HEADER */}
+          {/* ------------------------------------------------------ */}
+          <MainHeader seriesList={seriesList} tags={tags} />
 
-        {/* ------------------------------------------------------ */}
-        {/* ARTICLE */}
-        {/* ------------------------------------------------------ */}
-        {children}
+          {/* ------------------------------------------------------ */}
+          {/* ARTICLE */}
+          {/* ------------------------------------------------------ */}
+          {children}
 
-        {/* ------------------------------------------------------ */}
-        {/* Footer */}
-        {/* ------------------------------------------------------ */}
-        <MainFooter seriesList={seriesList} />
-      </div>
+          {/* ------------------------------------------------------ */}
+          {/* Footer */}
+          {/* ------------------------------------------------------ */}
+          <MainFooter seriesList={seriesList} />
+        </div>
+
+        {/* 검색 모달(전역) */}
+        <SearchModal />
+      </SearchProvider>
     </MainLayoutContext.Provider>
   );
 }

--- a/apps/blog/src/app/search-index.json/route.ts
+++ b/apps/blog/src/app/search-index.json/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { buildSearchIndex } from '@libs/api/build-search-index';
+
+// 빌드 타임에 정적 파일로 prerender 한다(런타임 서버 비용 0).
+export const dynamic = 'force-static';
+
+/**
+ * 클라이언트 검색이 사용할 정적 검색 인덱스(JSON)를 제공한다.
+ * GET /search-index.json
+ */
+export async function GET() {
+  const docs = await buildSearchIndex();
+  return NextResponse.json(docs);
+}

--- a/apps/blog/src/components/main-header.tsx
+++ b/apps/blog/src/components/main-header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { DropdownMenu } from './dropdown-menu';
 import { SeriesModel, TagModel } from '@libs/types/commons';
 import { MobileSidebar } from './mobile-sidebar';
+import { SearchButton } from './search';
 
 export interface MainHeaderProps {
   seriesList: SeriesModel[];
@@ -24,6 +25,9 @@ export function MainHeader({ seriesList, tags }: MainHeaderProps) {
         <MainHeaderLogo />
 
         <span className="grow"></span>
+
+        {/* === SEARCH BUTTON (모든 화면 크기에서 노출) === */}
+        <SearchButton className="mr-5 text-white" />
 
         {/* === HEADER >= MD: RIGHT SECTION === */}
         <nav className="gap-5 hidden md:flex">

--- a/apps/blog/src/components/search/index.ts
+++ b/apps/blog/src/components/search/index.ts
@@ -1,0 +1,3 @@
+export { SearchProvider, useSearch } from './search-context';
+export { SearchModal } from './search-modal';
+export { SearchButton } from './search-button';

--- a/apps/blog/src/components/search/search-button.tsx
+++ b/apps/blog/src/components/search/search-button.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import classNames from 'classnames';
+import { IconSearch } from '@tabler/icons-react';
+import { useSearch } from './search-context';
+
+interface SearchButtonProps {
+  className?: string;
+}
+
+/** 헤더에서 검색 모달을 여는 아이콘 버튼 */
+export function SearchButton({ className }: SearchButtonProps) {
+  const { open } = useSearch();
+
+  return (
+    <button
+      onClick={open}
+      aria-label="포스트 검색 열기"
+      className={classNames('flex cursor-pointer items-center', className)}
+    >
+      <IconSearch className="h-5 w-5" />
+    </button>
+  );
+}

--- a/apps/blog/src/components/search/search-context.tsx
+++ b/apps/blog/src/components/search/search-context.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import Fuse, { IFuseOptions } from 'fuse.js';
+import {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { SearchDoc } from '@libs/types/search';
+
+// 최대 노출 결과 수
+const MAX_RESULTS = 8;
+
+// Fuse 검색 옵션: 제목 > 태그 > 설명 > 본문 순으로 가중치 부여
+const FUSE_OPTIONS: IFuseOptions<SearchDoc> = {
+  keys: [
+    { name: 'title', weight: 0.5 },
+    { name: 'tags', weight: 0.3 },
+    { name: 'description', weight: 0.15 },
+    { name: 'content', weight: 0.05 },
+  ],
+  includeScore: true, // 정렬을 위해 점수 포함
+  ignoreLocation: true, // 매칭 위치 무관(긴 본문/한글 부분일치에 중요)
+  threshold: 0.35, // 너무 느슨하지 않게 매칭 임계값 설정
+  minMatchCharLength: 2, // 2글자 이상부터 매칭
+};
+
+// 인덱스 로딩 상태
+type IndexStatus = 'idle' | 'loading' | 'ready' | 'error';
+
+interface SearchContextValue {
+  isOpen: boolean; // 모달 열림 여부
+  open: () => void; // 모달 열기
+  close: () => void; // 모달 닫기
+  status: IndexStatus; // 인덱스 로딩 상태
+  search: (query: string) => SearchDoc[]; // 검색 실행
+}
+
+const SearchContext = createContext<SearchContextValue | null>(null);
+
+/** SearchProvider 하위에서 검색 상태/동작에 접근한다 */
+export function useSearch(): SearchContextValue {
+  const ctx = useContext(SearchContext);
+  if (!ctx) {
+    // Provider 밖에서 사용하는 실수를 빌드 단계에서 빨리 드러내기 위함
+    throw new Error('useSearch must be used within <SearchProvider>');
+  }
+  return ctx;
+}
+
+export function SearchProvider({ children }: PropsWithChildren) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [status, setStatus] = useState<IndexStatus>('idle');
+  // Fuse 인스턴스는 렌더링과 무관하므로 ref에 보관
+  const fuseRef = useRef<Fuse<SearchDoc> | null>(null);
+  // 로딩 중복 방지를 위한 플래그
+  const loadingRef = useRef(false);
+
+  // 검색 인덱스를 최초 1회만 lazy 로드한다
+  const loadIndex = useCallback(async () => {
+    if (fuseRef.current || loadingRef.current) return; // 이미 로드/로딩 중이면 skip
+    loadingRef.current = true;
+    setStatus('loading');
+    try {
+      const res = await fetch('/search-index.json');
+      if (!res.ok) {
+        throw new Error(`search index fetch failed: ${res.status}`);
+      }
+      const docs: SearchDoc[] = await res.json();
+      fuseRef.current = new Fuse(docs, FUSE_OPTIONS);
+      setStatus('ready');
+    } catch {
+      setStatus('error');
+    } finally {
+      loadingRef.current = false;
+    }
+  }, []);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    void loadIndex(); // 열 때 인덱스 로드 시작
+  }, [loadIndex]);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  const search = useCallback((query: string): SearchDoc[] => {
+    const fuse = fuseRef.current;
+    const keyword = query.trim();
+    if (!fuse || keyword.length === 0) return []; // 인덱스 없거나 빈 질의면 결과 없음
+    return fuse.search(keyword, { limit: MAX_RESULTS }).map((result) => result.item);
+  }, []);
+
+  // ⌘K / Ctrl+K 전역 단축키로 모달 토글
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setIsOpen((prev) => {
+          if (!prev) void loadIndex(); // 열릴 때 인덱스 로드
+          return !prev;
+        });
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [loadIndex]);
+
+  const value = useMemo<SearchContextValue>(
+    () => ({ isOpen, open, close, status, search }),
+    [isOpen, open, close, status, search],
+  );
+
+  return <SearchContext.Provider value={value}>{children}</SearchContext.Provider>;
+}

--- a/apps/blog/src/components/search/search-context.tsx
+++ b/apps/blog/src/components/search/search-context.tsx
@@ -60,6 +60,8 @@ export function SearchProvider({ children }: PropsWithChildren) {
   const fuseRef = useRef<Fuse<SearchDoc> | null>(null);
   // 로딩 중복 방지를 위한 플래그
   const loadingRef = useRef(false);
+  // 단축키 핸들러에서 최신 열림 상태를 참조하기 위한 ref
+  const isOpenRef = useRef(false);
 
   // 검색 인덱스를 최초 1회만 lazy 로드한다
   const loadIndex = useCallback(async () => {
@@ -82,11 +84,15 @@ export function SearchProvider({ children }: PropsWithChildren) {
   }, []);
 
   const open = useCallback(() => {
+    isOpenRef.current = true;
     setIsOpen(true);
     void loadIndex(); // 열 때 인덱스 로드 시작
   }, [loadIndex]);
 
-  const close = useCallback(() => setIsOpen(false), []);
+  const close = useCallback(() => {
+    isOpenRef.current = false;
+    setIsOpen(false);
+  }, []);
 
   const search = useCallback((query: string): SearchDoc[] => {
     const fuse = fuseRef.current;
@@ -100,15 +106,14 @@ export function SearchProvider({ children }: PropsWithChildren) {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
         e.preventDefault();
-        setIsOpen((prev) => {
-          if (!prev) void loadIndex(); // 열릴 때 인덱스 로드
-          return !prev;
-        });
+        // 부수효과는 setState 업데이터 밖에서 처리(open/close 재사용)
+        if (isOpenRef.current) close();
+        else open();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [loadIndex]);
+  }, [open, close]);
 
   const value = useMemo<SearchContextValue>(
     () => ({ isOpen, open, close, status, search }),

--- a/apps/blog/src/components/search/search-modal.tsx
+++ b/apps/blog/src/components/search/search-modal.tsx
@@ -114,6 +114,11 @@ export function SearchModal() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="포스트 검색…"
+            aria-label="포스트 검색"
+            role="combobox"
+            aria-expanded={results.length > 0}
+            aria-controls="search-result-list"
+            aria-activedescendant={results.length > 0 ? `search-option-${activeIndex}` : undefined}
             className="h-14 w-full bg-transparent text-base text-black outline-none placeholder:text-gray-400"
           />
           <button
@@ -146,9 +151,15 @@ export function SearchModal() {
             <p className="px-4 py-6 text-center text-sm text-gray-400">검색 결과가 없습니다.</p>
           )}
 
-          <ul>
+          <ul id="search-result-list" role="listbox">
             {results.map((doc, idx) => (
-              <li key={doc.route} ref={idx === activeIndex ? activeItemRef : null}>
+              <li
+                key={doc.route}
+                id={`search-option-${idx}`}
+                role="option"
+                aria-selected={idx === activeIndex}
+                ref={idx === activeIndex ? activeItemRef : null}
+              >
                 <Link
                   href={doc.route}
                   onClick={close}

--- a/apps/blog/src/components/search/search-modal.tsx
+++ b/apps/blog/src/components/search/search-modal.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import classNames from 'classnames';
+import { IconSearch, IconX } from '@tabler/icons-react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearch } from './search-context';
+
+export function SearchModal() {
+  const { isOpen, close, status, search } = useSearch();
+  const router = useRouter();
+  const [query, setQuery] = useState(''); // 입력 질의
+  const [activeIndex, setActiveIndex] = useState(0); // 키보드 활성 항목
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null); // 포커스 트랩 대상 컨테이너
+  const activeItemRef = useRef<HTMLLIElement>(null); // 현재 활성 결과 항목
+
+  // 질의/상태가 바뀔 때마다 결과 재계산
+  const results = useMemo(() => search(query), [search, query, status]);
+
+  // 모달이 열리면 입력 초기화 + 포커스, 배경 스크롤 잠금
+  useEffect(() => {
+    if (!isOpen) return;
+    setQuery('');
+    setActiveIndex(0);
+    // 렌더 직후 다음 프레임에 포커스
+    const frame = window.requestAnimationFrame(() => inputRef.current?.focus());
+    // 배경 스크롤 잠금
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen]);
+
+  // 질의가 바뀌면 활성 인덱스 초기화
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  // 키보드로 이동한 활성 항목이 항상 보이도록 스크롤
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  if (!isOpen) return null;
+
+  const keyword = query.trim();
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      close();
+      return;
+    }
+    // Tab 포커스를 모달 내부로 가둔다(포커스 트랩)
+    if (e.key === 'Tab') {
+      const container = containerRef.current;
+      if (!container) return;
+      const focusables = container.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last?.focus(); // 처음에서 Shift+Tab → 마지막으로 순환
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first?.focus(); // 마지막에서 Tab → 처음으로 순환
+      }
+      return;
+    }
+    if (results.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % results.length); // 다음 항목
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + results.length) % results.length); // 이전 항목
+    } else if (e.key === 'Enter') {
+      const target = results[activeIndex];
+      if (target) {
+        e.preventDefault();
+        router.push(target.route); // 클라이언트 라우팅으로 이동
+        close();
+      }
+    }
+  };
+
+  return (
+    // 배경 오버레이(클릭 시 닫힘)
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center bg-black/50 px-4 pt-[12vh]"
+      onClick={close}
+    >
+      {/* 모달 본체(내부 클릭은 닫힘 전파 차단) */}
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="포스트 검색"
+        className="w-full max-w-[640px] overflow-hidden rounded-xl bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+      >
+        {/* 검색 입력 영역 */}
+        <div className="flex items-center gap-3 border-b border-gray-200 px-4">
+          <IconSearch className="h-5 w-5 shrink-0 text-gray-400" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="포스트 검색…"
+            className="h-14 w-full bg-transparent text-base text-black outline-none placeholder:text-gray-400"
+          />
+          <button
+            onClick={close}
+            aria-label="검색 닫기"
+            className="shrink-0 text-gray-400 hover:text-black"
+          >
+            <IconX className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* 결과 영역 */}
+        <div className="max-h-[60vh] overflow-y-auto">
+          {status === 'loading' && (
+            <p className="px-4 py-6 text-center text-sm text-gray-400">
+              검색 인덱스를 불러오는 중…
+            </p>
+          )}
+          {status === 'error' && (
+            <p className="px-4 py-6 text-center text-sm text-red-500">
+              검색 인덱스를 불러오지 못했습니다.
+            </p>
+          )}
+          {status === 'ready' && keyword.length === 0 && (
+            <p className="px-4 py-6 text-center text-sm text-gray-400">
+              제목, 내용, 태그로 포스트를 검색하세요.
+            </p>
+          )}
+          {status === 'ready' && keyword.length > 0 && results.length === 0 && (
+            <p className="px-4 py-6 text-center text-sm text-gray-400">검색 결과가 없습니다.</p>
+          )}
+
+          <ul>
+            {results.map((doc, idx) => (
+              <li key={doc.route} ref={idx === activeIndex ? activeItemRef : null}>
+                <Link
+                  href={doc.route}
+                  onClick={close}
+                  onMouseEnter={() => setActiveIndex(idx)}
+                  className={classNames(
+                    'block border-b border-gray-100 px-4 py-3',
+                    idx === activeIndex ? 'bg-gray-100' : 'bg-white',
+                  )}
+                >
+                  <div className="flex items-center gap-2">
+                    {doc.series && (
+                      <span className="shrink-0 rounded bg-black px-1.5 py-0.5 text-[11px] text-white">
+                        {doc.series}
+                      </span>
+                    )}
+                    <span className="font-medium text-black">{doc.title}</span>
+                  </div>
+                  {doc.description && (
+                    <p className="mt-1 line-clamp-1 text-sm text-gray-500">{doc.description}</p>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/blog/src/libs/api/build-search-index.ts
+++ b/apps/blog/src/libs/api/build-search-index.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import { findPosts } from './find-posts';
+import { SearchDoc } from '@libs/types/search';
+
+// 인덱스 크기를 제한하기 위한 본문 길이 상한(문자 수)
+const CONTENT_CHAR_LIMIT = 8000;
+
+/**
+ * MDX/TSX 본문에서 검색에 사용할 평문 텍스트만 추출한다.
+ * (frontmatter, import/export, 코드 블록, JSX 태그, 마크다운 기호 제거)
+ */
+function extractPlainText(filePath: string): string {
+  let raw: string;
+  try {
+    // 파일 본문을 통째로 읽는다
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    // 읽기 실패 시 본문 없이 처리(메타데이터만으로도 검색 가능)
+    return '';
+  }
+
+  // 1) frontmatter({ ... }) 메타데이터 호출 블록을 괄호 짝을 세어 통째로 제거
+  const metaStart = raw.indexOf('frontmatter(');
+  if (metaStart !== -1) {
+    let depth = 0; // 괄호 깊이
+    let i = metaStart + 'frontmatter'.length; // 첫 '(' 위치
+    for (; i < raw.length; i++) {
+      const ch = raw[i];
+      if (ch === '(') depth++; // 여는 괄호를 만나면 깊이 증가
+      else if (ch === ')') {
+        depth--; // 닫는 괄호를 만나면 깊이 감소
+        if (depth === 0) {
+          i++; // 닫는 괄호 다음 위치까지 포함해 잘라낸다
+          break;
+        }
+      }
+    }
+    // frontmatter(...) 호출 부분을 앞/뒤로 잘라 제거
+    raw = raw.slice(0, metaStart) + raw.slice(i);
+  }
+
+  return (
+    raw
+      // import 구문 제거
+      .replace(/^import\s.+$/gm, ' ')
+      // export 구문 제거(메타데이터 잔여 라인 포함)
+      .replace(/^export\s.+$/gm, ' ')
+      // 펜스 코드 블록 제거
+      .replace(/```[\s\S]*?```/g, ' ')
+      // 인라인 코드 제거
+      .replace(/`[^`]*`/g, ' ')
+      // 이미지: alt 텍스트만 남김
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, ' $1 ')
+      // 링크: 표시 텍스트만 남김
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, ' $1 ')
+      // JSX/HTML 태그 제거
+      .replace(/<[^>]+>/g, ' ')
+      // 마크다운 기호 제거
+      .replace(/[#>*_~`|]/g, ' ')
+      // 연속 공백을 하나로 정규화
+      .replace(/\s+/g, ' ')
+      .trim()
+      // 인덱스 크기 상한 적용
+      .slice(0, CONTENT_CHAR_LIMIT)
+  );
+}
+
+/**
+ * 모든 포스트를 검색 문서(SearchDoc)로 변환한다.
+ * 빌드 타임(서버)에서만 실행되며, 결과는 정적 JSON으로 제공된다.
+ */
+export async function buildSearchIndex(): Promise<SearchDoc[]> {
+  // findPosts는 시리즈 랜딩 페이지를 제외한 실제 포스트만 반환한다
+  const posts = await findPosts({ orderBy: 'latest' });
+
+  return posts.map((post) => {
+    const fm = post.frontMatter;
+    return {
+      id: fm.id ?? post.slug,
+      title: fm.title,
+      description: fm.description ?? '',
+      series: fm.series ?? '',
+      tags: fm.tags ?? [],
+      route: post.route,
+      content: extractPlainText(post.filePath),
+    };
+  });
+}

--- a/apps/blog/src/libs/types/search.ts
+++ b/apps/blog/src/libs/types/search.ts
@@ -1,0 +1,13 @@
+/**
+ * 클라이언트/서버가 공유하는 검색 문서 타입.
+ * 서버 전용 코드(fs 사용)와 분리하기 위해 별도 파일로 둔다.
+ */
+export interface SearchDoc {
+  id: string; // 포스트 식별자(postId)
+  title: string; // 포스트 제목
+  description: string; // 포스트 요약
+  series: string; // 시리즈 id
+  tags: string[]; // 태그 목록
+  route: string; // 포스트 경로 (예: /posts/frontend/monorepo)
+  content: string; // 검색용 본문 평문 텍스트
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
+      fuse.js:
+        specifier: ^7.4.2
+        version: 7.4.2
       next:
         specifier: ^16.2.1
         version: 16.2.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
@@ -1219,6 +1222,10 @@ packages:
 
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  fuse.js@7.4.2:
+    resolution: {integrity: sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==}
+    engines: {node: '>=10'}
 
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
@@ -3347,6 +3354,8 @@ snapshots:
       functions-have-names: 1.2.3
 
   functions-have-names@1.2.3: {}
+
+  fuse.js@7.4.2: {}
 
   get-intrinsic@1.2.4:
     dependencies:


### PR DESCRIPTION
## 개요

포스트를 **제목·내용·태그**로 검색하는 기능을 추가합니다. 요구사항(비용 제로 / 운영부담 최소 / 결합도 최소 / 단순성 / 한글 검색 품질)에 맞춰 **클라이언트 사이드 정적 검색**으로 구현했습니다.

Closes #24

## 방법 선택: Fuse.js

현재 코퍼스(22편, 한글 위주)와 요구사항을 기준으로 후보를 비교했습니다.

| 요구사항 | **Fuse.js (채택)** | FlexSearch | Pagefind |
|---|---|---|---|
| 비용 제로 | 정적 JSON, $0 | $0 | $0 |
| 운영부담 | 무서버 | 무서버 | 빌드 HTML 크롤 필요(Vercel SSR과 마찰) |
| 결합도/단순성 | JSON 1개 + 자기완결 모듈, 타입 내장 | 한글 토크나이저 튜닝·타입 거침 | 별도 빌드 스텝 |
| 한글 품질 | 부분일치 native + 가중치 | CJK 인코더 튜닝 필요 | CJK 일부 |

FlexSearch(Nextra 기본)의 유일한 강점인 대규모 확장성은 현재 규모에서 무의미하고, 단순성/결합도/한글품질에서 Fuse.js가 우위라 채택했습니다.

## 동작 방식

1. **빌드 타임 인덱스** — `force-static` route handler `/search-index.json`가 빌드 시 정적 파일로 prerender됩니다(런타임 서버 비용 0).
   - `build-search-index.ts`가 MDX/TSX 본문에서 frontmatter·코드블록·JSX·마크다운 기호를 제거한 평문을 추출해 색인합니다.
2. **검색 UI** — 헤더 검색 아이콘 또는 `⌘K` / `Ctrl+K`로 모달을 엽니다.
   - 인덱스는 **최초 1회만 lazy 로드**, 이후 Fuse.js로 in-memory 검색.
   - 제목 > 태그 > 설명 > 본문 순 가중치, `ignoreLocation`으로 한글 부분일치 대응.
3. **접근성/UX** — 키보드 내비게이션(↑/↓/Enter/Esc), 활성 항목 자동 스크롤, 포커스 트랩, `role="dialog"`/`aria-modal` 적용.

## 변경 파일

- 신규: `libs/types/search.ts`, `libs/api/build-search-index.ts`, `app/search-index.json/route.ts`, `components/search/*`
- 수정: `main-client-layout.tsx`(Provider/모달 마운트), `main-header.tsx`(검색 버튼), `package.json`(fuse.js)

## 검증

- `pnpm build` 통과, `/search-index.json` 정적 생성 확인(22편 전부 본문 색인, frontmatter 누수 0).
- 한글 질의 실측: "모노레포/클로저/타입스크립트/호이스팅/스코프 체인/프로토타입 체인" 모두 정확한 포스트가 상위에 매칭됨.
- 다차원 적대적 리뷰 후 접근성 3건(포커스 트랩·ARIA·키보드 스크롤 동기화) 반영.

## 후속 고려(이번 PR 범위 외)

- 결과 본문 스니펫 하이라이트, 검색어 히스토리, 포스트 증가 시 인덱스 캐시 헤더 튜닝.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
