### PR TITLE
fix(tags): 미정의 태그 404·태그 인덱스 신설·메타데이터 보강 (#69)

### DIFF
--- a/apps/blog/src/app/(main)/tags/[tag]/page.tsx
+++ b/apps/blog/src/app/(main)/tags/[tag]/page.tsx
@@ -3,17 +3,40 @@ import { findPosts } from '@libs/api/find-posts';
 import { findSeriesList } from '@libs/api/find-series';
 import { findTags } from '@libs/api/find-tags';
 import { Mapper } from '@libs/mapper';
+import { PageLinkMap } from '@libs/page-link-map';
 import { PostModel, TagModel } from '@libs/types/commons';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 
-export interface GenerateMetadataProps {
-  params: any;
+// generateStaticParams가 전체 태그를 반환하므로, 미정의 태그(오타/없는 태그)는 404로 처리한다.
+export const dynamicParams = false;
+
+export interface TagPageParams {
+  // App Router 동적 세그먼트 params는 Promise로 전달된다.
+  params: Promise<{ tag: string }>;
 }
 
-export async function generateMetadata(props: GenerateMetadataProps) {
-  const params = await props.params;
+export async function generateMetadata(props: TagPageParams): Promise<Metadata> {
+  const { tag } = await props.params;
+  // URL 인코딩된 태그를 사람이 읽는 형태로 복원한다.
+  const tagId = decodeURIComponent(tag);
+
+  // 해당 태그가 달린 글 개수를 메타데이터 description에 활용한다.
+  const matchedCount = await findPosts().then(
+    (list) => list.filter((post) => post.frontMatter.tags?.includes(tagId)).length,
+  );
+
+  // 매칭되는 글이 없으면 검색엔진 색인에서 제외한다(빈 태그 페이지 노출 방지).
+  const shouldIndex = matchedCount > 0;
 
   return {
-    title: `Posts Tagged with “${decodeURIComponent(params.tag)}”`,
+    title: `Posts Tagged with “${tagId}”`,
+    description: `${tagId} 태그가 달린 글 ${matchedCount}개`,
+    // landing()이 내부에서 encodeURIComponent를 적용하므로 원본 tagId를 그대로 전달한다.
+    alternates: {
+      canonical: PageLinkMap.tags.landing(tagId),
+    },
+    robots: shouldIndex ? undefined : { index: false },
   };
 }
 
@@ -22,21 +45,21 @@ export async function generateStaticParams() {
   return [...new Set(allTags)].map((tag) => ({ tag }));
 }
 
-export interface TagPageProps {
-  params: any;
-}
-
-export default async function TagPage(props: TagPageProps) {
+export default async function TagPage(props: TagPageParams) {
   // 태그 조회 & 데이터 가공
-  const params = await props.params;
-  const tagId = decodeURIComponent(params.tag);
+  const { tag } = await props.params;
+  const tagId = decodeURIComponent(tag);
   const tagModel: TagModel = { id: tagId };
 
   //   포스트 조회
-  const { title } = await generateMetadata({ params });
   const posts = await findPosts().then((list) =>
     list.filter((post) => post.frontMatter.tags?.includes(tagId)),
   );
+
+  // dynamicParams=false로 미정의 태그는 차단되지만, 정의된 태그라도 매칭 글이 0개면 방어적으로 404 처리한다.
+  if (posts.length === 0) {
+    notFound();
+  }
 
   //   PostModel로 가공
   const seriesList = await findSeriesList();

--- a/apps/blog/src/app/(main)/tags/page.tsx
+++ b/apps/blog/src/app/(main)/tags/page.tsx
@@ -1,0 +1,58 @@
+import { ArticleHeader } from '@components/article';
+import { ArticleContainer } from '@components/article-container';
+import { Divider } from '@components/divider';
+import { TagBadge } from '@components/tag-badge';
+import { findPosts } from '@libs/api/find-posts';
+import { findTags } from '@libs/api/find-tags';
+import { PageLinkMap } from '@libs/page-link-map';
+import type { Metadata } from 'next';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const tagCount = (await findTags()).length;
+
+  return {
+    title: 'Tags',
+    description: `블로그의 전체 태그 ${tagCount}개를 모아보는 페이지입니다.`,
+    // 표기 일관성을 위해 canonical 경로를 명시한다.
+    alternates: {
+      canonical: PageLinkMap.tags.index(),
+    },
+  };
+}
+
+export default async function TagsIndexPage() {
+  // 전체 태그와 전체 글을 조회한다.
+  const tags = [...new Set(await findTags())];
+  const posts = await findPosts();
+
+  // 태그별 글 개수를 미리 집계해 배지 옆에 함께 표기한다.
+  const countByTag = new Map<string, number>();
+  posts.forEach((post) => {
+    post.frontMatter.tags?.forEach((tag) => {
+      countByTag.set(tag, (countByTag.get(tag) ?? 0) + 1);
+    });
+  });
+
+  return (
+    <ArticleContainer>
+      <div className="pb-[200px]">
+        {/* 기존 시리즈/태그 상세와 동일한 헤더 레이아웃을 재사용해 일관성을 유지한다. */}
+        <ArticleHeader subTitle={'Malloc72p.Tech.Tags'} title={'Tags'} />
+
+        <Divider />
+
+        <article className="py-[65px]">
+          <div className="flex flex-wrap gap-4">
+            {tags.map((tag) => (
+              // 태그 배지와 글 개수를 함께 묶어 노출한다.
+              <span key={tag} className="flex items-center gap-1">
+                <TagBadge tagId={tag} />
+                <span className="text-xs text-gray-500 md:text-sm">{countByTag.get(tag) ?? 0}</span>
+              </span>
+            ))}
+          </div>
+        </article>
+      </div>
+    </ArticleContainer>
+  );
+}

--- a/apps/blog/src/components/badge.tsx
+++ b/apps/blog/src/components/badge.tsx
@@ -22,14 +22,16 @@ export function Badge({ href, children, onClick, color = 'secondary' }: BadgePro
       className={classNames(
         'rounded-md flex items-center justify-center font-bold',
         'transition-all duration-200 ease-in-out',
-        'px-[8px] py-[6px]',
-        'md:px-[12px]',
+        // 모바일 탭 영역 확보를 위해 세로 패딩을 키운다(데스크톱은 기존 유지).
+        'px-[8px] py-[8px]',
+        'md:px-[12px] md:py-[6px]',
         'whitespace-nowrap',
         color === 'primary' ? 'bg-gray-700 text-white' : 'bg-gray-100 text-gray-700',
         'hover:brightness-95 active:brightness-90',
       )}
     >
-      <Link href={href} className="text-[10px] md:text-[16px]" onClick={onBadgeClick}>
+      {/* 모바일 가독성을 위해 폰트를 12px로 올린다(데스크톱은 기존 16px 유지). */}
+      <Link href={href} className="text-[12px] md:text-[16px]" onClick={onBadgeClick}>
         {children}
       </Link>
     </span>

--- a/apps/blog/src/components/main-header.tsx
+++ b/apps/blog/src/components/main-header.tsx
@@ -42,17 +42,11 @@ export function MainHeader({ seriesList, tags }: MainHeaderProps) {
               href: PageLinkMap.series.landing(series.id),
             }))}
           />
-          {/* === TAGS DROPDOWN MENU === */}
-          {/* <DropdownMenu
-            title="Tags"
-            width={160}
-            // leftOffset={-25}
-            items={tags.map((tag) => ({
-              id: tag.id,
-              label: tag.id,
-              href: PageLinkMap.tags.landing(tag.id),
-            }))}
-          /> */}
+          {/* === TAGS INDEX LINK ===
+              태그가 49개로 많아 드롭다운 대신 전체 태그 인덱스 페이지로 가는 링크를 노출한다. */}
+          <Link href={PageLinkMap.tags.index()} className="flex items-center">
+            Tags
+          </Link>
         </nav>
 
         {/* === HEADER < MD: RIGHT SECTION === */}
@@ -65,7 +59,8 @@ export function MainHeader({ seriesList, tags }: MainHeaderProps) {
 export function MainHeaderLogo() {
   return (
     <Link href={PageLinkMap.main.landing()}>
-      <h1 className="text-[16px] md:text-[40px]">Malloc72p.Tech</h1>
+      {/* 로고는 페이지 제목이 아니므로 h1 대신 span으로 강등한다. 페이지 고유 제목만 h1로 남긴다. */}
+      <span className="block text-[16px] md:text-[40px]">Malloc72p.Tech</span>
     </Link>
   );
 }

--- a/apps/blog/src/components/tag-badge.tsx
+++ b/apps/blog/src/components/tag-badge.tsx
@@ -7,8 +7,9 @@ export interface TagBadgeProps {
 }
 
 export function TagBadge({ tagId, onClick }: TagBadgeProps) {
+  // sitemap과 표기를 맞추기 위해 태그 ID를 인코딩해 링크를 생성한다(저위험 변경).
   return (
-    <Badge href={`/tags/${tagId}`} onClick={onClick}>
+    <Badge href={`/tags/${encodeURIComponent(tagId)}`} onClick={onClick}>
       {tagId}
     </Badge>
   );

--- a/apps/blog/src/components/tag-detail/tag-detail.tsx
+++ b/apps/blog/src/components/tag-detail/tag-detail.tsx
@@ -2,7 +2,9 @@ import { ArticleHeader } from '@components/article';
 import { ArticleContainer } from '@components/article-container';
 import { Divider } from '@components/divider';
 import { PostCard } from '@components/post-card';
+import { PageLinkMap } from '@libs/page-link-map';
 import { PostModel, TagModel } from '@libs/types/commons';
+import Link from 'next/link';
 
 export interface TagDetailProps {
   tag: TagModel;
@@ -18,11 +20,31 @@ export async function TagDetail({ tag, posts }: TagDetailProps) {
         <Divider />
 
         <article className="py-[65px]">
-          {posts.map((post) => (
-            <PostCard key={post.route} post={post} series={post.series} />
-          ))}
+          {/* 방어적 빈 상태: 해당 태그에 글이 없으면 안내 문구와 이동 링크를 노출한다. */}
+          {posts.length === 0 ? (
+            <TagDetailEmptyState />
+          ) : (
+            posts.map((post) => <PostCard key={post.route} post={post} series={post.series} />)
+          )}
         </article>
       </div>
     </ArticleContainer>
+  );
+}
+
+// 글이 없는 태그를 위한 빈 상태 UI. 홈/태그 인덱스로 돌아갈 수 있는 경로를 제공한다.
+function TagDetailEmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-4 text-center text-gray-600">
+      <p>이 태그에 해당하는 글이 아직 없습니다.</p>
+      <div className="flex gap-5">
+        <Link href={PageLinkMap.main.landing()} className="underline hover:text-gray-900">
+          홈으로
+        </Link>
+        <Link href={PageLinkMap.tags.index()} className="underline hover:text-gray-900">
+          전체 태그 보기
+        </Link>
+      </div>
+    </div>
   );
 }

--- a/apps/blog/src/libs/page-link-map.ts
+++ b/apps/blog/src/libs/page-link-map.ts
@@ -9,6 +9,9 @@ export const PageLinkMap = {
     detail: (seriesId: string, postId: string) => `/posts/${seriesId}/${postId}`,
   },
   tags: {
-    landing: (tagId: string) => `/tags/${tagId}`,
+    // 전체 태그 인덱스 페이지 경로.
+    index: () => '/tags',
+    // sitemap과 표기를 맞추기 위해 태그 ID를 인코딩해 경로를 만든다(저위험 변경).
+    landing: (tagId: string) => `/tags/${encodeURIComponent(tagId)}`,
   },
 };


### PR DESCRIPTION
## 개요
이슈 #69(태그 페이지)의 결함·개선 항목을 수정한다.

Closes #69

## 변경 사항
### 🔴 결함 수정
- **없는 태그 404 처리**: `tags/[tag]/page.tsx`에 `dynamicParams=false` + 매칭 글 0개 시 `notFound()`. 기존엔 오타/없는 태그도 입력 문자열을 제목으로 한 빈 페이지를 200으로 렌더했음.
- **태그 발견성**: `/tags` 전체 태그 인덱스 페이지 신설(태그별 글 개수 표기), 데스크톱 헤더에 `/tags` 진입점 복구(기존 주석 처리됨).

### 🟡 개선
- `generateMetadata`에 `description`/`alternates.canonical` 추가, 빈·없는 태그 `robots:{index:false}`. `params: any` → `Promise<{ tag: string }>`.
- 전역 헤더 로고 `<h1>` → `<span>` 강등(시각 스타일 유지) → 페이지당 h1 1개.
- 링크 생성부(`tag-badge`, `page-link-map`)에 sitemap과 동일한 `encodeURIComponent` 적용(표기 일관성, 저위험).

### ⚪ 기타
- 모바일 태그/시리즈 배지 폰트 10→12px, 세로 패딩 확대(터치 타겟).

> 태그 대소문자 통합 매칭(정규화)은 기존 URL/프리렌더 회귀 위험이 커서 이번 범위에서 제외.

## 테스트 플랜
- [ ] 없는 태그 URL → 404
- [ ] `/tags` 인덱스에 전체 태그 + 개수 노출, 데스크톱 헤더 Tags 진입
- [ ] `/tags/Typescript`, 한글/공백 태그 정상 렌더
- [ ] 페이지당 h1 1개
- [ ] `pnpm --filter blog build` 통과(태그 정적 prerender)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
