### PR TITLE
fix(landing): 소개카드 가독성·헤더 탭영역·첫화면 밀도·a11y (#67)

### DIFF
--- a/apps/blog/src/app/(main)/main-client-page.tsx
+++ b/apps/blog/src/app/(main)/main-client-page.tsx
@@ -105,13 +105,16 @@ export function MainClientPage({ seriesPosts }: MainClientPageProps) {
         {/* ------------------------------------------------------ */}
         {/* SERIES */}
         {/* ------------------------------------------------------ */}
-        <div className="my-[30px] md:my-[65px] flex flex-wrap gap-5">
+        {/* 데스크톱 첫 화면에 포스트가 더 들어오도록 세로 마진을 md:my-[65px]에서 절반 수준(32px)으로 축소한다. 모바일(my-[30px])은 유지. */}
+        <div className="my-[30px] md:my-[32px] flex flex-wrap gap-5">
           {seriesFilters.map((series) => (
             <SeriesBadge
               key={series.id}
               seriesId={series.id}
               title={series.title}
               color={series.active ? 'primary' : 'secondary'}
+              // 활성 필터를 보조기술에 알리기 위해 active 값을 aria-current로 내려준다.
+              active={series.active}
               onClick={() => changeSeriesFilter(series.id)}
             />
           ))}
@@ -125,7 +128,8 @@ export function MainClientPage({ seriesPosts }: MainClientPageProps) {
         {/* ------------------------------------------------------ */}
         {/* ARTICLE */}
         {/* ------------------------------------------------------ */}
-        <div className="my-[30px] md:my-[65px]">
+        {/* 아티클 영역도 동일하게 세로 마진을 md:my-[65px]에서 절반 수준(32px)으로 축소한다. 모바일(my-[30px])은 유지. */}
+        <div className="my-[30px] md:my-[32px]">
           {posts.map((post) => {
             const series = seriesList.find((currentSeries) => currentSeries.id === post.series.id);
 

--- a/apps/blog/src/components/badge.tsx
+++ b/apps/blog/src/components/badge.tsx
@@ -6,9 +6,11 @@ export interface BadgeProps extends PropsWithChildren {
   onClick?: () => void;
   href: string;
   color?: 'primary' | 'secondary';
+  // 현재 선택된(활성) 필터 여부. 보조기술에 현재 항목임을 알리기 위해 aria-current로 연결된다.
+  active?: boolean;
 }
 
-export function Badge({ href, children, onClick, color = 'secondary' }: BadgeProps) {
+export function Badge({ href, children, onClick, color = 'secondary', active }: BadgeProps) {
   const onBadgeClick = onClick
     ? (e: React.MouseEvent) => {
         e.preventDefault();
@@ -31,7 +33,13 @@ export function Badge({ href, children, onClick, color = 'secondary' }: BadgePro
       )}
     >
       {/* 모바일 가독성을 위해 폰트를 12px로 올린다(데스크톱은 기존 16px 유지). */}
-      <Link href={href} className="text-[12px] md:text-[16px]" onClick={onBadgeClick}>
+      {/* 활성 필터일 때만 aria-current="true"를 부여해 보조기술에 현재 선택 항목임을 알린다. */}
+      <Link
+        href={href}
+        className="text-[12px] md:text-[16px]"
+        onClick={onBadgeClick}
+        aria-current={active ? 'true' : undefined}
+      >
         {children}
       </Link>
     </span>

--- a/apps/blog/src/components/dropdown-menu.tsx
+++ b/apps/blog/src/components/dropdown-menu.tsx
@@ -2,7 +2,6 @@
 
 import { IconChevronDown } from '@tabler/icons-react';
 import classNames from 'classnames';
-import { Html } from 'next/document';
 import Link from 'next/link';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 

--- a/apps/blog/src/components/introduce-card.tsx
+++ b/apps/blog/src/components/introduce-card.tsx
@@ -1,8 +1,9 @@
 import classNames from 'classnames';
 
 export function IntroduceCard() {
+  // 데스크톱 첫 화면 밀도 확보를 위해 상단 마진을 md:mt-30(120px)에서 절반 수준(60px)으로 축소한다. 모바일(mt-7.5)은 유지.
   return (
-    <div className="rounded-md border border-gray-100 flex relative shadow-md mt-7.5 md:mt-30 break-keep">
+    <div className="rounded-md border border-gray-100 flex relative shadow-md mt-7.5 md:mt-15 break-keep">
       {/* === INTRODUCE CARD LEFT Bar === */}
       <div className="w-2 md:w-4.25 h-full bg-gray-700  absolute left-0 top-0"></div>
 
@@ -15,9 +16,9 @@ export function IntroduceCard() {
         </div>
 
         {/* === INTRODUCE CARD DESCRIPTION ABOUT ME === */}
-        <span className="text-gray-600 mt-4 text-[10px] md:text-[16px]">
-          환영합니다! 개발하면서 경험한 지식을 공유하기 위해 직접 디자인하고 개발한 블로그입니다.{' '}
-          <br /> 많은 관심 부탁드립니다!
+        {/* 모바일 가독성을 위해 본문 폰트를 10px에서 13px로 상향한다(데스크톱은 16px 유지). 하드코딩 <br /> 제거 후 break-keep 자동 줄바꿈에 맡긴다. */}
+        <span className="text-gray-600 mt-4 text-[13px] md:text-[16px]">
+          환영합니다! 개발하면서 경험한 지식을 공유하기 위해 직접 디자인하고 개발한 블로그입니다. 많은 관심 부탁드립니다!
         </span>
       </div>
     </div>

--- a/apps/blog/src/components/main-header.tsx
+++ b/apps/blog/src/components/main-header.tsx
@@ -58,7 +58,11 @@ export function MainHeader({ seriesList, tags }: MainHeaderProps) {
 
 export function MainHeaderLogo() {
   return (
-    <Link href={PageLinkMap.main.landing()}>
+    // 다크 헤더 위에서 키보드 포커스가 보이도록 밝은 outline + offset을 부여한다.
+    <Link
+      href={PageLinkMap.main.landing()}
+      className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2"
+    >
       {/* 로고는 페이지 제목이 아니므로 h1 대신 span으로 강등한다. 페이지 고유 제목만 h1로 남긴다. */}
       <span className="block text-[16px] md:text-[40px]">Malloc72p.Tech</span>
     </Link>

--- a/apps/blog/src/components/mobile-sidebar.tsx
+++ b/apps/blog/src/components/mobile-sidebar.tsx
@@ -22,8 +22,9 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
       {/* ------------------------------------------------------ */}
       {/* SIDEBAR TRIGGER */}
       {/* ------------------------------------------------------ */}
-      <div className="flex md:hidden cursor-pointer">
-        <IconMenu2 className="w-5 h-5" onClick={() => setOpen(true)} />
+      {/* 탭 영역 확대를 위해 래퍼에 패딩(p-2.5)을 주고 onClick을 래퍼로 올린다(아이콘 크기는 유지). */}
+      <div className="flex md:hidden cursor-pointer p-2.5" onClick={() => setOpen(true)}>
+        <IconMenu2 className="w-5 h-5" />
       </div>
 
       {/* ------------------------------------------------------ */}
@@ -46,7 +47,8 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
           {/* ------------------------------------------------------ */}
           {/* SIDEBAR CLOSE BUTTON */}
           {/* ------------------------------------------------------ */}
-          <div className="flex items-center cursor-pointer" onClick={() => setOpen(false)}>
+          {/* 탭 영역 확대를 위해 닫기 버튼 래퍼에 패딩(p-2.5)을 더한다(아이콘 크기는 유지). */}
+          <div className="flex items-center cursor-pointer p-2.5" onClick={() => setOpen(false)}>
             <IconX className="w-5 h-5 " />
           </div>
         </div>

--- a/apps/blog/src/components/search/search-button.tsx
+++ b/apps/blog/src/components/search/search-button.tsx
@@ -16,7 +16,14 @@ export function SearchButton({ className }: SearchButtonProps) {
     <button
       onClick={open}
       aria-label="포스트 검색 열기"
-      className={classNames('flex cursor-pointer items-center', className)}
+      className={classNames(
+        'flex cursor-pointer items-center',
+        // 아이콘(20px)에 패딩을 더해 탭 영역을 ~44px로 확보한다(아이콘 크기는 유지).
+        'p-2.5',
+        // 다크 헤더 위에서 키보드 포커스가 보이도록 밝은 outline + offset을 부여한다.
+        'focus-visible:outline focus-visible:outline-2 focus-visible:outline-white focus-visible:outline-offset-2',
+        className,
+      )}
     >
       <IconSearch className="h-5 w-5" />
     </button>

--- a/apps/blog/src/components/series-badge.tsx
+++ b/apps/blog/src/components/series-badge.tsx
@@ -5,11 +5,19 @@ export interface SeriesBadgeProps {
   title: string;
   onClick?: () => void;
   color?: 'primary' | 'secondary';
+  // 현재 선택된 필터 여부. Badge로 전달되어 aria-current 표기에 사용된다.
+  active?: boolean;
 }
 
-export function SeriesBadge({ seriesId, title, onClick, color = 'secondary' }: SeriesBadgeProps) {
+export function SeriesBadge({
+  seriesId,
+  title,
+  onClick,
+  color = 'secondary',
+  active,
+}: SeriesBadgeProps) {
   return (
-    <Badge href={seriesId ? `/posts/${seriesId}` : '#'} onClick={onClick} color={color}>
+    <Badge href={seriesId ? `/posts/${seriesId}` : '#'} onClick={onClick} color={color} active={active}>
       {title}
     </Badge>
   );


### PR DESCRIPTION
## 개요
이슈 #67(랜딩 페이지 UX/UI)의 개선 항목을 수정한다.

Closes #67

## 변경 사항
### 🔴 결함/가독성
- 모바일 소개카드 본문 폰트 `text-[10px]` → `text-[13px]`(데스크톱 16px 유지).

### 🟡 개선
- 소개카드 하드코딩 `<br/>` 제거 → 자동 줄바꿈(`break-keep`).
- 헤더 검색/햄버거/닫기 아이콘에 패딩(`p-2.5`) 추가로 탭 영역 확대(20→40px). 햄버거는 onClick을 패딩 래퍼로 이동해 영역 전체가 클릭되게 함.
- 데스크톱 첫 화면 밀도 개선: 소개카드 `md:mt-30`→`md:mt-15`, 필터/아티클 `md:my-[65px]`→`md:my-[32px]`.

### ⚪ 접근성
- 다크 헤더 위 로고/검색에 `focus-visible` 밝은 outline + offset.
- 시리즈 필터 활성 배지에 `aria-current="true"`.
- 미사용 `import { Html } from 'next/document'`(dropdown-menu) 제거.

## 테스트 플랜
- [ ] 모바일 소개카드 본문 13px, `<br/>` 제거된 자연 줄바꿈
- [ ] 헤더 아이콘 탭 영역 확대(~40px), 키보드 포커스 가시성
- [ ] 데스크톱 1280×800 첫 화면에 포스트 2~3개 노출
- [ ] 활성 필터 `aria-current`
- [ ] `pnpm --filter blog build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
