### PR TITLE
feat(series): 현재 시리즈 active·온페이지 칩·카드 어포던스 (#68)

### DIFF
--- a/apps/blog/src/components/dropdown-menu.tsx
+++ b/apps/blog/src/components/dropdown-menu.tsx
@@ -4,6 +4,7 @@ import { IconChevronDown } from '@tabler/icons-react';
 import classNames from 'classnames';
 import { Html } from 'next/document';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 export interface DropdownMenuItemProps {
@@ -27,6 +28,9 @@ export function DropdownMenu({ title, items, leftOffset = 0, ...option }: Dropdo
   /* ------------------------------------------------------ */
   const [visible, setVisible] = useState(false);
   const [offsetX, setOffsetX] = useState(0);
+
+  // 현재 경로를 읽어 드롭다운 항목 중 활성 시리즈를 강조한다.
+  const pathname = usePathname();
 
   /* ------------------------------------------------------ */
   /* REFS */
@@ -128,21 +132,32 @@ export function DropdownMenu({ title, items, leftOffset = 0, ...option }: Dropdo
         {/* ------------------------------------------------------ */}
         {/* DROPDOWN BODY ITEMS */}
         {/* ------------------------------------------------------ */}
-        {items.map((item) => (
-          <li
-            key={item.id}
-            onClick={() => {
-              setVisible(false);
-            }}
-          >
-            <Link
-              href={item.href}
-              className="block hover:underline p-3 w-full cursor-pointer rounded-md transition-all duration-300"
+        {items.map((item) => {
+          // href가 현재 경로와 정확히 일치하면 활성 항목으로 표시한다.
+          const active = item.href === pathname;
+
+          return (
+            <li
+              key={item.id}
+              onClick={() => {
+                setVisible(false);
+              }}
             >
-              {item.label}
-            </Link>
-          </li>
-        ))}
+              <Link
+                href={item.href}
+                // 활성 항목은 스크린리더가 현재 위치를 인지하도록 aria-current를 부여한다.
+                aria-current={active ? 'page' : undefined}
+                className={classNames(
+                  'block hover:underline p-3 w-full cursor-pointer rounded-md transition-all duration-300',
+                  // 활성 항목은 굵게 + 밑줄로 강조한다.
+                  active && 'font-bold underline',
+                )}
+              >
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/apps/blog/src/components/main-footer.tsx
+++ b/apps/blog/src/components/main-footer.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import { PageLinkMap } from '@libs/page-link-map';
 import { SeriesModel } from '@libs/types/commons';
 import { IconArrowUp } from '@tabler/icons-react';
 import classNames from 'classnames';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import React, { PropsWithChildren, ReactNode } from 'react';
 
 export interface MainFooterProps {
@@ -79,6 +82,9 @@ interface FooterListProps {
 }
 
 function FooterList({ label, items }: FooterListProps) {
+  // 현재 경로를 읽어 SERIES 목록에서 활성 항목을 강조한다.
+  const pathname = usePathname();
+
   return (
     <div className="md:w-[200px] md:ml-10 mt-10 md:mt-0 mb-10">
       {/* === MAIN FOOTER LIST === */}
@@ -87,7 +93,8 @@ function FooterList({ label, items }: FooterListProps) {
       <ul className="mt-5">
         {items.map((item) => (
           <li key={item.id}>
-            <LinkButton href={item.href} color="primary">
+            {/* href가 현재 경로와 정확히 일치하면 활성 항목으로 표시한다. */}
+            <LinkButton href={item.href} color="primary" active={item.href === pathname}>
               {item.label}
             </LinkButton>
           </li>
@@ -102,6 +109,8 @@ interface LinkButtonProps extends PropsWithChildren {
   onClick?: () => void;
   color?: 'primary' | 'secondary';
   leftIcon?: React.ElementType;
+  // 현재 보고 있는 시리즈 항목인지 여부(활성 강조 및 aria-current 처리에 사용).
+  active?: boolean;
 }
 
 function LinkButton({
@@ -110,10 +119,13 @@ function LinkButton({
   leftIcon: Icon,
   children,
   color = 'secondary',
+  active = false,
 }: LinkButtonProps) {
   return (
     <Link
       href={href ?? '#'}
+      // 활성 항목은 스크린리더가 현재 위치를 인지하도록 aria-current를 부여한다.
+      aria-current={active ? 'page' : undefined}
       onClick={
         onClick
           ? (e) => {
@@ -131,6 +143,8 @@ function LinkButton({
           color === 'primary'
             ? 'text-gray-600 hover:text-gray-900'
             : 'text-gray-600 hover:text-gray-700',
+          // 활성 항목은 굵게 + 진한 색 + 밑줄로 강조한다.
+          active && 'font-bold text-gray-900 underline',
         )}
       >
         {Icon && <Icon className="w-4 h-4" />}

--- a/apps/blog/src/components/mobile-sidebar.tsx
+++ b/apps/blog/src/components/mobile-sidebar.tsx
@@ -5,6 +5,7 @@ import { MainHeaderLogo, MainHeaderProps } from './main-header';
 import { IconMenu2, IconMenu3, IconX } from '@tabler/icons-react';
 import classNames from 'classnames';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { PageLinkMap } from '@libs/page-link-map';
 import { Divider } from './divider';
 
@@ -91,6 +92,9 @@ interface SidebarSectionProps {
 }
 
 function SidebarSection({ title, items, onClick }: SidebarSectionProps) {
+  // 현재 경로를 읽어 Series 목록에서 활성 항목을 강조한다.
+  const pathname = usePathname();
+
   return (
     <div className="sidebar-section">
       <div className="pb-3 text-lg">
@@ -99,11 +103,24 @@ function SidebarSection({ title, items, onClick }: SidebarSectionProps) {
       </div>
 
       <ul className="space-y-2">
-        {items.map((item) => (
-          <li key={item.id} onClick={onClick}>
-            <Link href={item.href}>{item.label}</Link>
-          </li>
-        ))}
+        {items.map((item) => {
+          // href가 현재 경로와 정확히 일치하면 활성 항목으로 표시한다.
+          const active = item.href === pathname;
+
+          return (
+            <li key={item.id} onClick={onClick}>
+              <Link
+                href={item.href}
+                // 활성 항목은 스크린리더가 현재 위치를 인지하도록 aria-current를 부여한다.
+                aria-current={active ? 'page' : undefined}
+                // 활성 항목은 굵게 + 밑줄로 강조한다.
+                className={classNames(active && 'font-bold underline')}
+              >
+                {item.label}
+              </Link>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/apps/blog/src/components/post-card.tsx
+++ b/apps/blog/src/components/post-card.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { PostModel, SeriesModel } from '@libs/types/commons';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { SeriesBadge } from './series-badge';
 import { TagBadge } from './tag-badge';
@@ -7,27 +10,52 @@ import { DateUtil } from '@libs/date-util';
 export interface PostCardProps {
   post: PostModel;
   series: SeriesModel;
+  // 혼합 목록(최신글/태그/랜딩)에서만 시리즈 배지를 노출한다. 단일 시리즈 페이지에선 false.
+  showSeriesBadge?: boolean;
 }
 
 /**
  * 랜딩페이지의 포스트 목록보기에서 사용하는 포스트 카드 컴포넌트
  */
-export function PostCard({ post, series }: PostCardProps) {
+export function PostCard({ post, showSeriesBadge = true }: PostCardProps) {
+  const router = useRouter();
+
+  // 카드 전체를 클릭하면 포스트로 이동시켜 클릭 영역을 넓힌다(제목 Link는 접근성용으로 유지).
+  const onCardClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // 카드 내부의 배지/링크(<a>)를 클릭한 경우엔 해당 링크가 처리하도록 카드 이동을 막는다.
+    if ((e.target as HTMLElement).closest('a')) {
+      return;
+    }
+
+    router.push(post.route);
+  };
+
   return (
-    <div key={post.route} className="px-3 mb-[42px]">
+    <div
+      key={post.route}
+      onClick={onCardClick}
+      // hover 시 배경/보더/포인터로 카드 전체가 클릭 가능함을 시각적으로 알린다.
+      className="px-3 py-3 mb-[30px] rounded-lg border border-transparent cursor-pointer transition-all duration-200 hover:bg-gray-50 hover:border-gray-200"
+    >
       {/* === POST TITLE AND LINK === */}
+      {/* 제목 Link는 키보드 포커스/새 탭 열기 등 접근성을 위해 실제 <a>로 유지한다. */}
       <Link href={post.route}>
-        <span className="text-xs md:text-lg font-bold">{post.title}</span>
+        {/* 모바일 제목을 키워 태그(배지)와 위계를 확보한다. */}
+        <span className="text-sm md:text-lg font-bold">{post.title}</span>
       </Link>
 
-      <div className="text-gray-600 text-xs mb:text-[16px] mt-1 sm:mt-2">
+      {/* 목록에서는 분/시 없이 날짜만 노출한다(date-format의 postCard 패턴 사용). */}
+      <div className="text-gray-600 text-xs md:text-[16px] mt-1 sm:mt-2">
         {DateUtil.format(post.date, 'postCard')}
       </div>
 
       {/* === POST SERIES & TAG CONTAINER === */}
       <div className="mt-3 flex flex-wrap gap-3">
-        {/* === POST SERIES === */}
-        <SeriesBadge seriesId={series.id} title={series.title} />
+        {/* === POST SERIES ===
+            혼합 목록에서만, 각 포스트의 실제 시리즈를 배지로 노출한다. */}
+        {showSeriesBadge && (
+          <SeriesBadge seriesId={post.series.id} title={post.series.title} />
+        )}
 
         {/* === POST TAGS === */}
         {post.tags.map((tag) => (

--- a/apps/blog/src/components/series-detail/series-detail.tsx
+++ b/apps/blog/src/components/series-detail/series-detail.tsx
@@ -4,8 +4,12 @@ import { Divider } from '@components/divider';
 import { PostCard } from '@components/post-card';
 import { findPosts } from '@libs/api/find-posts';
 import { findSeriesList } from '@libs/api/find-series';
+import { Constants } from '@libs/constants';
 import { Mapper } from '@libs/mapper';
+import { PageLinkMap } from '@libs/page-link-map';
 import { SeriesModel } from '@libs/types/commons';
+import classNames from 'classnames';
+import Link from 'next/link';
 
 export interface SeriesDetailProps {
   series: SeriesModel;
@@ -18,18 +22,70 @@ export async function SeriesDetail({ series }: SeriesDetailProps) {
 
   const posts = allPosts.map((item) => Mapper.toPostModel({ item, seriesModels }));
 
+  // latest 시리즈는 여러 시리즈가 섞인 목록이므로 카드에 시리즈 배지를 노출한다.
+  const showSeriesBadge = series.id === Constants.series.latestId;
+
   return (
     <ArticleContainer>
-      <div className="pb-[200px]">
+      {/* 글이 적은 시리즈에서 과도한 하단 공백이 생기지 않도록 반응형으로 축소한다. */}
+      <div className="pb-20 md:pb-32">
         <ArticleHeader subTitle={'Malloc72p.Tech.Series'} title={series.title} />
+
+        {/* === 온페이지 시리즈 전환 칩 ===
+            한 번의 클릭으로 다른 시리즈로 이동할 수 있도록 모든 시리즈 칩을 노출하고
+            현재 시리즈는 강조한다. */}
+        <nav aria-label="시리즈 전환" className="flex flex-wrap justify-center gap-2 pb-6">
+          {seriesModels.map((item) => {
+            // 현재 보고 있는 시리즈와 동일하면 활성 칩으로 강조한다.
+            const active = item.id === series.id;
+
+            return (
+              <Link
+                key={item.id}
+                href={PageLinkMap.series.landing(item.id)}
+                aria-current={active ? 'page' : undefined}
+                className={classNames(
+                  'rounded-full font-bold whitespace-nowrap',
+                  'px-3 py-1.5 text-xs md:text-sm',
+                  'transition-all duration-200 ease-in-out',
+                  active
+                    ? // 활성 시리즈: 진한 배경으로 강조한다.
+                      'bg-gray-900 text-white'
+                    : // 비활성 시리즈: 옅은 배경 + hover 강조로 클릭 가능함을 알린다.
+                      'bg-gray-100 text-gray-700 hover:bg-gray-200',
+                )}
+              >
+                {item.title}
+              </Link>
+            );
+          })}
+        </nav>
+
+        {/* === 글 개수 표시 ===
+            현재 시리즈에 포함된 포스트 개수를 안내한다. */}
+        <p className="text-center text-xs md:text-sm text-gray-600 pb-4">
+          {posts.length}개의 포스트
+        </p>
 
         <Divider />
 
-        <article className="py-[65px]">
-          {posts.map((post) => (
-            <PostCard key={post.route} post={post} series={series} />
-          ))}
-        </article>
+        {/* posts가 비어 있으면 빈 상태 문구를 보여주고, 아니면 카드 목록을 렌더링한다. */}
+        {posts.length === 0 ? (
+          <div className="py-[65px] text-center text-gray-600">
+            아직 이 시리즈에 작성된 포스트가 없습니다.
+          </div>
+        ) : (
+          <article className="py-[65px]">
+            {posts.map((post) => (
+              <PostCard
+                key={post.route}
+                post={post}
+                series={series}
+                showSeriesBadge={showSeriesBadge}
+              />
+            ))}
+          </article>
+        )}
       </div>
     </ArticleContainer>
   );

--- a/apps/blog/src/libs/date-util/date-format.ts
+++ b/apps/blog/src/libs/date-util/date-format.ts
@@ -5,5 +5,5 @@ export const DateFormat: Record<IDateFormat, string> = {
   short: 'YYYY-MM-DD',
   file: 'YYMMDD_HHmmss',
   iso: 'YYYY-MM-DDTHH:mm',
-  postCard: 'YYYY/MM/DD a h:mm',
+  postCard: 'YYYY. MM. DD',
 };


### PR DESCRIPTION
## 개요
이슈 #68(시리즈 목록 페이지 UX/UI)의 개선 항목을 수정한다.

Closes #68

## 변경 사항
### 🔴 핵심
- **현재 시리즈 active 표시**: 푸터·헤더 드롭다운·모바일 사이드바의 시리즈 항목에 `usePathname()` 비교로 `aria-current="page"` + 강조 스타일.
- **온페이지 시리즈 전환 칩**: 시리즈 페이지 H1 아래에 4개 시리즈 칩을 추가, 현재 시리즈 강조, 한 번 클릭 전환.

### 🟡 개선
- 시리즈별 **글 개수 표기**("N개의 포스트") + 빈 상태 문구.
- 포스트 카드: 카드 전체 클릭 + hover 어포던스(배지/제목 링크는 `closest('a')`로 분리해 중첩 `<a>` 없음). 단일 시리즈에선 시리즈 배지 숨김, 혼합 목록(latest 등)에선 각 포스트 실제 시리즈 표시. 모바일 제목 `text-xs`→`text-sm`.
- **`mb:text-[16px]` 오타 → `md:text-[16px]`** (날짜 텍스트가 데스크톱에서 커지도록).
- 목록 카드 날짜 포맷 `YYYY/MM/DD a h:mm` → `YYYY. MM. DD`(분 단위 제거; 상세 페이지는 별도 'long' 포맷이라 영향 없음).
- 글 적은 시리즈 하단 여백 `pb-[200px]` → `pb-20 md:pb-32`.

## 테스트 플랜
- [ ] 4개 시리즈에서 현재 시리즈 active 표시(nav/footer/sidebar)
- [ ] 온페이지 칩으로 시리즈 전환
- [ ] 글 개수 정확(latest 24·frontend 17·ai 4·fullstack 3)
- [ ] 카드 전체 클릭/hover, 배지 클릭은 각 대상으로 분리
- [ ] 날짜 `2026. 06. 22` 형식
- [ ] `pnpm --filter blog build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
