### PR TITLE
fix(build): sitemap 이중 슬래시·ESLint 구동 복구·lint 스크립트 (#71)

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -1,3 +1,6 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
 import createMDX from '@next/mdx';
 
 const withMDX = createMDX({
@@ -6,12 +9,16 @@ const withMDX = createMDX({
   },
 });
 
+// 이 설정 파일 위치(apps/blog) 기준 두 단계 상위가 모노레포(pnpm 워크스페이스) 루트다
+const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],
-  //   experimental: {
-  //     optimizeCss: true,
-  //   },
+  // 모노레포에서 워크스페이스 루트 자동 추론으로 인한 경고를 막기 위해 Turbopack 루트를 워크스페이스 루트로 고정한다
+  turbopack: {
+    root: workspaceRoot,
+  },
 };
 
 export default withMDX(nextConfig);

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "lint": "next lint --max-warnings 0",
+    "lint": "eslint . --max-warnings 0",
     "dev": "TZ=\"Atlantic/Reykjavik\" next",
     "build": "next build",
     "start": "next start"

--- a/apps/blog/src/app/sitemap.ts
+++ b/apps/blog/src/app/sitemap.ts
@@ -25,7 +25,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   for (const post of posts) {
     sitemaps.push({
-      url: [url, post.route].join('/'),
+      // post.route는 이미 '/posts/...'로 시작하므로 join('/') 대신 직접 연결해 이중 슬래시를 방지한다
+      url: `${url}${post.route}`,
       priority: 0.8,
       lastModified: DateUtil.Dayjs(post.date).toDate(),
     });

--- a/apps/blog/tailwind.config.js
+++ b/apps/blog/tailwind.config.js
@@ -1,9 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: [
-    './src/pages/**/*.{js,ts,jsx,tsx}',
-    './src/components/**/*.{js,ts,jsx,tsx}',
-    './src/app/**/*.{js,ts,jsx,tsx}',
+    // 컴포넌트/앱 라우트와 MDX 포스트(page.mdx)까지 클래스 스캔 대상에 포함한다
+    './src/components/**/*.{js,ts,jsx,tsx,md,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,md,mdx}',
     './src/mdx-components.{js,ts,jsx,tsx}',
   ],
   theme: {

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -4,9 +4,6 @@ import tseslint from 'typescript-eslint';
 import onlyWarn from 'eslint-plugin-only-warn';
 // @ts-check
 import turboPlugin from 'eslint-plugin-turbo';
-import eslint from '@eslint/js';
-import eslintConfigPrettier from 'eslint-config-prettier';
-import tseslint from 'typescript-eslint';
 
 /**
  * A shared ESLint configuration for the repository.
@@ -14,7 +11,7 @@ import tseslint from 'typescript-eslint';
  * @type {import("eslint").Linter.Config}
  * */
 export const config = tseslint.config(
-  eslint.configs.recommended,
+  js.configs.recommended,
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
   { ignores: ['jest.config.js'] },

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -14,7 +14,8 @@ export const config = tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
-  { ignores: ['jest.config.js'] },
+  // 빌드 산출물·커버리지 등은 린트 대상에서 제외한다(없으면 `eslint .`가 .next 등을 린트해 폭발한다).
+  { ignores: ['jest.config.js', '.next/**', 'out/**', 'dist/**', 'coverage/**'] },
   {
     plugins: {
       turbo: turboPlugin,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@next/eslint-plugin-next": "^15.1.0",
+    "@next/eslint-plugin-next": "^16.2.1",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
     "@typescript-eslint/parser": "^8.15.0",
     "eslint": "^9.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^9.17.0
         version: 9.17.0
       '@next/eslint-plugin-next':
-        specifier: ^15.1.0
-        version: 15.1.0
+        specifier: ^16.2.1
+        version: 16.2.9
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.15.0
         version: 8.15.0(@typescript-eslint/parser@8.15.0(eslint@9.15.0(jiti@2.6.1))(typescript@5.5.4))(eslint@9.15.0(jiti@2.6.1))(typescript@5.5.4)
@@ -390,8 +390,8 @@ packages:
   '@next/env@16.2.1':
     resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
 
-  '@next/eslint-plugin-next@15.1.0':
-    resolution: {integrity: sha512-+jPT0h+nelBT6HC9ZCHGc7DgGVy04cv4shYdAe6tKlEbjQUtwU3LzQhzbDHQyY2m6g39m6B0kOFVuLGBrxxbGg==}
+  '@next/eslint-plugin-next@16.2.9':
+    resolution: {integrity: sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==}
 
   '@next/mdx@16.2.1':
     resolution: {integrity: sha512-w0YOkOc+WEnsTJ8uxzBOvpe3R+9BnJOxWCE7qcI/62CzJiUEd8JKtF25e3R8cW5BGsKyRW8p4zE2JLyXKa8xdw==}
@@ -2479,7 +2479,7 @@ snapshots:
 
   '@next/env@16.2.1': {}
 
-  '@next/eslint-plugin-next@15.1.0':
+  '@next/eslint-plugin-next@16.2.9':
     dependencies:
       fast-glob: 3.3.1
 


### PR DESCRIPTION
## 개요
이슈 #71(빌드 파이프라인 결함)의 핵심 결함을 수정한다.

Closes #71

## 변경 사항
### 🔴 결함 수정
- **sitemap 이중 슬래시 제거**: 포스트 URL `[url, post.route].join('/')`(→`//posts`)를 템플릿 리터럴 직접 연결로. 시리즈/태그 루프는 정상이라 미변경.
- **ESLint 구동 불능 복구**: `packages/eslint-config/base.js`의 중복 import 3줄 제거(`Identifier already declared` SyntaxError 해소), `js.configs.recommended`로 통일.
- **lint 스크립트**: `next lint --max-warnings 0`(Next 16에서 제거됨) → `eslint . --max-warnings 0`.
- **빌드 산출물 ignore**: `eslint .`가 `.next/`까지 린트해 폭발하던 문제 → `.next/out/dist/coverage`를 ESLint ignore에 추가(소스만 검사).

### 🟡/⚪ 기타
- `@next/eslint-plugin-next` `^15.1.0` → `^16.2.1`(Next 16 정합).
- `next.config.mjs`: 주석 `optimizeCss` 제거 + `turbopack.root`(모노레포 루트) 명시 → **워크스페이스 루트 추론 경고 제거**.
- `tailwind.config.js`: 없는 `./src/pages/**` 제거, `.md`/`.mdx` 추가.

> 이미 #69에서 해결된 항목(태그 링크 `encodeURIComponent`, tags 페이지 `params` 타입)은 범위에서 제외.

## 검증
- `pnpm --filter blog build` → **exit 0**(24개 포스트 생성), 워크스페이스 루트 경고 **0**.
- sitemap 산출물에 `//posts` **0건**(URL `https://blog.malloc72p.com/posts/...`).
- `pnpm --filter blog lint` → ESLint **정상 구동(SyntaxError 0)**.

## 후속(이 PR 범위 밖, 합의됨)
- **기존 lint 경고 19건(에러 0)**: lint이 비로소 동작하며 드러난 누적 부채(`no-unused-vars` 9·`exhaustive-deps` 4·`no-unescaped-entities` 2·`no-empty-object-type` 2·`prefer-const` 1·`no-explicit-any` 1, 10개 파일). `--max-warnings 0`이라 `pnpm lint`는 아직 빨강. exhaustive-deps는 동작 회귀 위험이 있어 별도 정리.
- **`Mapper.toPostModel`의 throw 완화**: 호출부 5곳(sitemap/layout/page/tags/series-detail)에 반환 타입이 번져 별도 작업으로 분리. 현재 seriesId 전부 유효해 동작은 안전.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
