### PR TITLE
fix(build): ESLint 경고 19건 정리 + Mapper throw 완화 (#77)

### DIFF
--- a/apps/blog/src/app/(main)/layout.tsx
+++ b/apps/blog/src/app/(main)/layout.tsx
@@ -1,6 +1,7 @@
 import { findSeriesList } from '@libs/api/find-series';
 import { findTags } from '@libs/api/find-tags';
 import { Mapper } from '@libs/mapper';
+import { PostModel } from '@libs/types/commons';
 import { PropsWithChildren } from 'react';
 import MainClientLayout from './main-client-layout';
 import { findPosts } from '@libs/api/find-posts';
@@ -17,6 +18,8 @@ export default async function MainLayout({ children }: PropsWithChildren) {
   const tags = (await findTags()).map(Mapper.toTagModel);
   const posts = (await findPosts())
     .map((item) => Mapper.toPostModel({ item, seriesModels }))
+    // 시리즈 미존재로 스킵된 포스트(null)를 제거해 PostModel[]로 좁힌다.
+    .filter((post): post is PostModel => post !== null)
     .sort((a, b) => a.date.localeCompare(b.date));
   const postDesc = posts.slice().reverse();
 

--- a/apps/blog/src/app/(main)/main-client-layout.tsx
+++ b/apps/blog/src/app/(main)/main-client-layout.tsx
@@ -30,12 +30,15 @@ export default function MainClientLayout({
   posts,
   children,
 }: MainClientLayoutProps) {
+  // 랜딩 데이터(posts/seriesList/tags)는 force-static 서버 컴포넌트에서 한 번 계산되어
+  // 내려오는 정적 값이므로, 마운트 시 1회만 컨텍스트를 구성하고 이후 재계산하지 않는다.
   const contextState = useMemo<MainLayoutContextType>(
     () => ({
       tags,
       seriesList,
       posts,
     }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
   );
 

--- a/apps/blog/src/app/(main)/main-client-page.tsx
+++ b/apps/blog/src/app/(main)/main-client-page.tsx
@@ -6,7 +6,7 @@ import { SeriesBadge } from '@components/series-badge';
 import { Constants } from '@libs/constants';
 import { DateUtil } from '@libs/date-util';
 import { PageLinkMap } from '@libs/page-link-map';
-import { PostModel, SeriesModel, TagModel } from '@libs/types/commons';
+import { PostModel, SeriesModel } from '@libs/types/commons';
 import { IconArrowRight } from '@tabler/icons-react';
 import classNames from 'classnames';
 import Link from 'next/link';
@@ -34,7 +34,7 @@ export function MainClientPage({ seriesPosts }: MainClientPageProps) {
   /* ------------------------------------------------------ */
   /* CONTEXT */
   /* ------------------------------------------------------ */
-  const { seriesList, tags } = useContext(MainLayoutContext);
+  const { seriesList } = useContext(MainLayoutContext);
 
   /* ------------------------------------------------------ */
   /* STATES */

--- a/apps/blog/src/app/(main)/page.tsx
+++ b/apps/blog/src/app/(main)/page.tsx
@@ -24,7 +24,10 @@ export default async function LandingPage() {
       seriesId: series.id,
     });
 
-    seriesPosts[series.id] = seriesPost.map((item) => Mapper.toPostModel({ item, seriesModels }));
+    seriesPosts[series.id] = seriesPost
+      .map((item) => Mapper.toPostModel({ item, seriesModels }))
+      // 시리즈 미존재로 스킵된 포스트(null)를 제거해 PostModel[]로 좁힌다.
+      .filter((post): post is PostModel => post !== null);
   }
 
   return <MainClientPage seriesPosts={seriesPosts} />;

--- a/apps/blog/src/app/(main)/tags/[tag]/page.tsx
+++ b/apps/blog/src/app/(main)/tags/[tag]/page.tsx
@@ -64,7 +64,10 @@ export default async function TagPage(props: TagPageParams) {
   //   PostModel로 가공
   const seriesList = await findSeriesList();
   const seriesModels = seriesList.map(Mapper.toSeriesModel);
-  const postModels: PostModel[] = posts.map((p) => Mapper.toPostModel({ item: p, seriesModels }));
+  const postModels: PostModel[] = posts
+    .map((p) => Mapper.toPostModel({ item: p, seriesModels }))
+    // 시리즈 미존재로 스킵된 포스트(null)를 제거해 PostModel[]로 좁힌다.
+    .filter((post): post is PostModel => post !== null);
 
   return <TagDetail tag={tagModel} posts={postModels} />;
 }

--- a/apps/blog/src/app/sitemap.ts
+++ b/apps/blog/src/app/sitemap.ts
@@ -4,11 +4,15 @@ import { findTags } from '@libs/api/find-tags';
 import { Constants } from '@libs/constants';
 import { DateUtil } from '@libs/date-util';
 import { Mapper } from '@libs/mapper';
+import { PostModel } from '@libs/types/commons';
 import { MetadataRoute } from 'next';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const seriesModels = (await findSeriesList()).map((item) => Mapper.toSeriesModel(item));
-  const posts = (await findPosts()).map((item) => Mapper.toPostModel({ item, seriesModels }));
+  const posts = (await findPosts())
+    .map((item) => Mapper.toPostModel({ item, seriesModels }))
+    // 시리즈 미존재로 스킵된 포스트(null)를 제거해 PostModel[]로 좁힌다.
+    .filter((post): post is PostModel => post !== null);
   const tags = await findTags();
   const uniqueTags = [...new Set(tags)];
 

--- a/apps/blog/src/components/dropdown-menu.tsx
+++ b/apps/blog/src/components/dropdown-menu.tsx
@@ -19,8 +19,6 @@ export interface DropdownMenuProps {
   leftOffset?: number;
 }
 
-const HIDE_TIMEOUT_LENGTH = 0;
-
 export function DropdownMenu({ title, items, leftOffset = 0, ...option }: DropdownMenuProps) {
   /* ------------------------------------------------------ */
   /* STATES */
@@ -36,7 +34,6 @@ export function DropdownMenu({ title, items, leftOffset = 0, ...option }: Dropdo
   /* ------------------------------------------------------ */
   const rootRef = useRef<HTMLDivElement>(null);
   const dropdownBodyRef = useRef<HTMLUListElement>(null);
-  const hideTimeoutRef = useRef<any>(null);
 
   /* ------------------------------------------------------ */
   /* FUNCTIONS */
@@ -63,6 +60,9 @@ export function DropdownMenu({ title, items, leftOffset = 0, ...option }: Dropdo
   /* ------------------------------------------------------ */
   /* EFFECTS */
   /* ------------------------------------------------------ */
+  // 마운트 시 1회 위치 보정 + resize 리스너 등록만 수행한다.
+  // adjustOffsetX는 매 렌더마다 새로 생성되므로 의존성에 넣으면 리스너가 반복 재등록되어
+  // 동작이 바뀐다. 최신 ref/state를 클로저로 읽으므로 빈 배열로 1회만 실행한다.
   useLayoutEffect(() => {
     adjustOffsetX();
 
@@ -71,6 +71,7 @@ export function DropdownMenu({ title, items, leftOffset = 0, ...option }: Dropdo
     return () => {
       window.removeEventListener('resize', adjustOffsetX);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/apps/blog/src/components/mdx-wrapper.tsx
+++ b/apps/blog/src/components/mdx-wrapper.tsx
@@ -25,7 +25,7 @@ export function MdxWrapper({ children }: MdxWrapperProps) {
   if (!series || !post) return null;
 
   return (
-    <PostDetail series={series} post={post} tags={tags} bottomContent={undefined}>
+    <PostDetail series={series} post={post} tags={tags}>
       {children}
     </PostDetail>
   );

--- a/apps/blog/src/components/mobile-sidebar.tsx
+++ b/apps/blog/src/components/mobile-sidebar.tsx
@@ -2,14 +2,15 @@
 
 import { useState } from 'react';
 import { MainHeaderLogo, MainHeaderProps } from './main-header';
-import { IconMenu2, IconMenu3, IconX } from '@tabler/icons-react';
+import { IconMenu2, IconX } from '@tabler/icons-react';
 import classNames from 'classnames';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { PageLinkMap } from '@libs/page-link-map';
 import { Divider } from './divider';
 
-export interface MobileSidebarProps extends MainHeaderProps {}
+// MainHeaderProps와 동일한 props를 받으므로 빈 인터페이스 대신 타입 별칭으로 둔다.
+export type MobileSidebarProps = MainHeaderProps;
 
 export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
   const [open, setOpen] = useState(false);

--- a/apps/blog/src/components/post-detail/post-codeblock.tsx
+++ b/apps/blog/src/components/post-detail/post-codeblock.tsx
@@ -1,7 +1,8 @@
 import React, { PropsWithChildren } from 'react';
 import { PostCodeblockClient } from './post-codeblock-client';
 
-export interface PostCodeblockProps extends PropsWithChildren {}
+// children만 받으므로 빈 인터페이스 대신 타입 별칭으로 둔다.
+export type PostCodeblockProps = PropsWithChildren;
 
 export function PostCodeblock(props: PostCodeblockProps) {
   const { children } = props;

--- a/apps/blog/src/components/post-detail/post-detail.tsx
+++ b/apps/blog/src/components/post-detail/post-detail.tsx
@@ -6,7 +6,7 @@ import { Divider } from '@components/divider';
 import { PostJsonLd } from '@components/post-json-ld';
 import { PostModel, SeriesModel, TagModel } from '@libs/types/commons';
 import classNames from 'classnames';
-import { PropsWithChildren, ReactNode, useEffect, useRef, useState } from 'react';
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import classes from './post-detail.module.scss';
 import { Toc, TocItem } from './toc';
 import { PostNavigator, PostNavigatorPlaceholder } from './post-navigator';
@@ -16,7 +16,6 @@ export interface PostDetailProps extends PropsWithChildren {
   series: SeriesModel;
   tags: TagModel[];
   post: PostModel;
-  bottomContent?: ReactNode;
 }
 
 /**
@@ -36,12 +35,7 @@ function slugify(text: string): string {
  *
  * mdx-components에서 해당 컴포넌트를 사용해서 블로그 상세 페이지를 랜더링한다.
  */
-export function PostDetail({
-  children,
-  series,
-  post,
-  bottomContent = null,
-}: PostDetailProps) {
+export function PostDetail({ children, series, post }: PostDetailProps) {
   const [activeTocId, setActiveTocId] = useState('');
   // 본문 DOM에서 헤딩을 수집해 만든 목차 데이터. 빌드 타임이 아닌 마운트 후 클라이언트에서 채운다.
   const [toc, setToc] = useState<TocItem[]>([]);

--- a/apps/blog/src/components/post-detail/post-image.tsx
+++ b/apps/blog/src/components/post-detail/post-image.tsx
@@ -23,7 +23,7 @@ export function PostImage({ src, alt, blur }: PostImageProps) {
         priority
       />
       <span className="block text-gray-600 text-center leading-[28px] italic py-5 break-words">
-        "{alt}"
+        &quot;{alt}&quot;
       </span>
     </span>
   );

--- a/apps/blog/src/components/post-detail/post-navigator.tsx
+++ b/apps/blog/src/components/post-detail/post-navigator.tsx
@@ -1,9 +1,7 @@
-import { PageLinkMap } from '@libs/page-link-map';
 import { PostModel } from '@libs/types/commons';
 import { IconSquareChevronLeft, IconSquareChevronRight } from '@tabler/icons-react';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { useState } from 'react';
 
 export interface PostNavigatorProps {
   mode: 'prev' | 'next';

--- a/apps/blog/src/components/post-detail/toc.tsx
+++ b/apps/blog/src/components/post-detail/toc.tsx
@@ -28,12 +28,16 @@ export function Toc({ toc, activeId, onFragIdChanged }: TocProps) {
     }
   }, []);
 
+  // fragId가 바뀔 때만 스크롤 이동 콜백을 호출한다.
+  // onFragIdChanged는 부모(PostDetail)에서 매 렌더마다 새로 생성되는 인라인 콜백이라
+  // 의존성에 넣으면 부모 리렌더마다 effect가 재실행되어 의도치 않은 scrollIntoView가 발생한다.
   useEffect(() => {
     if (!fragId) {
       return;
     }
 
     onFragIdChanged({ fragId });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fragId]);
 
   return (

--- a/apps/blog/src/components/search/search-modal.tsx
+++ b/apps/blog/src/components/search/search-modal.tsx
@@ -16,8 +16,8 @@ export function SearchModal() {
   const containerRef = useRef<HTMLDivElement>(null); // 포커스 트랩 대상 컨테이너
   const activeItemRef = useRef<HTMLLIElement>(null); // 현재 활성 결과 항목
 
-  // 질의/상태가 바뀔 때마다 결과 재계산
-  const results = useMemo(() => search(query), [search, query, status]);
+  // 질의가 바뀔 때마다 결과 재계산(status는 콜백에서 참조하지 않아 의존성에서 제외)
+  const results = useMemo(() => search(query), [search, query]);
 
   // 모달이 열리면 입력 초기화 + 포커스, 배경 스크롤 잠금
   useEffect(() => {

--- a/apps/blog/src/components/series-detail/series-detail.tsx
+++ b/apps/blog/src/components/series-detail/series-detail.tsx
@@ -7,7 +7,7 @@ import { findSeriesList } from '@libs/api/find-series';
 import { Constants } from '@libs/constants';
 import { Mapper } from '@libs/mapper';
 import { PageLinkMap } from '@libs/page-link-map';
-import { SeriesModel } from '@libs/types/commons';
+import { PostModel, SeriesModel } from '@libs/types/commons';
 import classNames from 'classnames';
 import Link from 'next/link';
 
@@ -20,7 +20,10 @@ export async function SeriesDetail({ series }: SeriesDetailProps) {
   const seriesList = await findSeriesList();
   const seriesModels = seriesList.map(Mapper.toSeriesModel);
 
-  const posts = allPosts.map((item) => Mapper.toPostModel({ item, seriesModels }));
+  const posts = allPosts
+    .map((item) => Mapper.toPostModel({ item, seriesModels }))
+    // 시리즈 미존재로 스킵된 포스트(null)를 제거해 PostModel[]로 좁힌다.
+    .filter((post): post is PostModel => post !== null);
 
   // latest 시리즈는 여러 시리즈가 섞인 목록이므로 카드에 시리즈 배지를 노출한다.
   const showSeriesBadge = series.id === Constants.series.latestId;

--- a/apps/blog/src/components/tag-badge.tsx
+++ b/apps/blog/src/components/tag-badge.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { Badge } from './badge';
 
 export interface TagBadgeProps {

--- a/apps/blog/src/libs/date-util/date-util.ts
+++ b/apps/blog/src/libs/date-util/date-util.ts
@@ -24,7 +24,7 @@ const toLocalTime = (date: string | Date) => {
  * @returns 포맷 문자열에 맞게 출력된 날짜 문자열
  */
 const format = (date: string | Date | dayjs.Dayjs, formatType: IDateFormat) => {
-  let dayjsObj = dayjs.isDayjs(date) ? date : dayjs.tz(date, DateUtil.tzString.seoul);
+  const dayjsObj = dayjs.isDayjs(date) ? date : dayjs.tz(date, DateUtil.tzString.seoul);
 
   const pattern = DateFormat[formatType];
   const result = dayjsObj.format(pattern);

--- a/apps/blog/src/libs/mapper.ts
+++ b/apps/blog/src/libs/mapper.ts
@@ -7,11 +7,14 @@ const toPostModel = ({
 }: {
   item: MdxFileInfo; // Item → MdxFileInfo
   seriesModels: SeriesModel[];
-}): PostModel => {
+}): PostModel | null => {
   const series = seriesModels.find((s) => s.id === item.frontMatter.series);
 
+  // 시리즈가 없으면 throw로 빌드 전체를 실패시키는 대신 경고만 남기고 해당 포스트를 스킵한다.
+  // 호출부는 반환된 null을 타입 가드 필터로 걸러 PostModel[]로 좁힌다.
   if (!series) {
-    throw new Error(`Series Not Found! id: ${item.frontMatter.series}`);
+    console.warn(`[Mapper] Series Not Found, skip post. id: ${item.frontMatter.series}`);
+    return null;
   }
 
   return {


### PR DESCRIPTION
## 개요
#71에서 ESLint 구동을 복구하며 드러난 경고와, 분리해 둔 `Mapper` throw 완화를 처리한다.

Closes #77

## Part 1 — ESLint 경고 19건 정리 → `pnpm lint` 통과
- 미사용 식별자 제거: `main-client-page`(TagModel·tags), `dropdown-menu`(HIDE_TIMEOUT_LENGTH·hideTimeoutRef=any 동시 해소), `mobile-sidebar`(IconMenu3), `post-detail`+`mdx-wrapper`(bottomContent), `post-navigator`(PageLinkMap·useState), `tag-badge`(Link)
- `no-empty-object-type`: `mobile-sidebar`·`post-codeblock`의 빈 `interface ... extends` → `type X = Y`
- `no-unescaped-entities`: `post-image` 캡션 따옴표 이스케이프
- `prefer-const`: `date-util`의 `dayjsObj` let→const
- **react-hooks/exhaustive-deps 4건(동작 보존 우선)**:
  - `search-modal`: 불필요한 `status` 의존성 **제거**
  - `main-client-layout`(useMemo)·`dropdown-menu`(useLayoutEffect)·`toc`(useEffect): 의도된 1회 실행/인라인 콜백이라 의존성 추가 시 동작이 바뀌므로 **사유 명시 `eslint-disable-next-line`** 처리

## Part 2 — `Mapper.toPostModel` throw 완화
- 시리즈 미존재 시 `throw`(빌드 전체 실패) → `console.warn` + `return null`
- 반환 타입 `PostModel | null`, 호출부 5곳(`sitemap`·`page`·`layout`·`tags/[tag]/page`·`series-detail`)에 `.filter((p): p is PostModel => p !== null)` 타입 가드(`any`·non-null 미사용)

## 검증
- `pnpm --filter blog lint` → **exit 0** (경고 0)
- `pnpm --filter blog build` → **exit 0**, 포스트 상세 **24개 그대로 생성**, Mapper skip 경고 0건(출력 불변)
- 추가된 라인에 `any`/non-null 단언 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
