### PR TITLE
feat(comments): giscus(GitHub Discussions) 기반 댓글 도입 (#11)

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -11,6 +11,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@giscus/react": "^3.1.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@tabler/icons-react": "^3.31.0",

--- a/apps/blog/src/components/post-detail/giscus-comments.tsx
+++ b/apps/blog/src/components/post-detail/giscus-comments.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import Giscus from '@giscus/react';
+
+/**
+ * GitHub Discussions 기반 댓글 위젯(giscus).
+ *
+ * 별도 DB·백엔드 없이 GitHub Discussions에 댓글을 저장한다(비용 0, 유지보수 부담 최소).
+ * 글 경로(pathname)로 글↔Discussion을 매핑하므로, 글마다 대응되는 Discussion이
+ * 첫 댓글 시 자동 생성된다.
+ *
+ * 동작에는 저장소에 giscus GitHub App 설치가 필요하다(앱 설치는 저장소 소유자만 가능).
+ */
+export function GiscusComments() {
+  return (
+    <Giscus
+      // 댓글이 저장될 저장소와 그 GraphQL 노드 ID
+      repo="Malloc72P/Blog"
+      repoId="R_kgDON30DhA"
+      // Announcements 카테고리: 일반 사용자는 Discussion을 직접 만들 수 없고 giscus만 생성한다
+      category="Announcements"
+      categoryId="DIC_kwDON30DhM4C_oxb"
+      // 글 경로(pathname) 기준으로 글과 Discussion을 1:1 매핑
+      mapping="pathname"
+      // pathname 매핑이라 제목 완전일치(strict)는 불필요
+      strict="0"
+      reactionsEnabled="1"
+      emitMetadata="0"
+      // 입력창을 댓글 목록 아래에 배치
+      inputPosition="bottom"
+      // 블로그가 라이트 테마라 라이트로 고정
+      theme="light"
+      lang="ko"
+      // 뷰포트에 들어올 때 로드해 초기 렌더 비용을 줄인다
+      loading="lazy"
+    />
+  );
+}

--- a/apps/blog/src/components/post-detail/post-detail.tsx
+++ b/apps/blog/src/components/post-detail/post-detail.tsx
@@ -11,6 +11,7 @@ import classes from './post-detail.module.scss';
 import { Toc, TocItem } from './toc';
 import { PostNavigator, PostNavigatorPlaceholder } from './post-navigator';
 import { PostRecommendation } from './post-recommendation';
+import { GiscusComments } from './giscus-comments';
 
 export interface PostDetailProps extends PropsWithChildren {
   series: SeriesModel;
@@ -221,6 +222,11 @@ export function PostDetail({ children, series, post }: PostDetailProps) {
           </div>
 
           <PostRecommendation />
+
+          {/* === 댓글 (giscus · GitHub Discussions 기반, DB 없음) === */}
+          <div className="mt-16 md:mt-24">
+            <GiscusComments />
+          </div>
         </footer>
       </section>
     </ArticleContainer>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/blog:
     dependencies:
+      '@giscus/react':
+        specifier: ^3.1.0
+        version: 3.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1
@@ -188,6 +191,12 @@ packages:
   '@eslint/plugin-kit@0.2.3':
     resolution: {integrity: sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@giscus/react@3.1.0':
+    resolution: {integrity: sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg==}
+    peerDependencies:
+      react: ^16 || ^17 || ^18 || ^19
+      react-dom: ^16 || ^17 || ^18 || ^19
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -369,6 +378,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
   '@mdx-js/loader@3.1.1':
     resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
@@ -685,6 +700,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1235,6 +1253,9 @@ packages:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
     engines: {node: '>= 0.4'}
 
+  giscus@1.6.0:
+    resolution: {integrity: sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1555,6 +1576,15 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit@3.3.3:
+    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2300,6 +2330,12 @@ snapshots:
     dependencies:
       levn: 0.4.1
 
+  '@giscus/react@3.1.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      giscus: 1.6.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2433,6 +2469,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
 
   '@mdx-js/loader@3.1.1':
     dependencies:
@@ -2708,6 +2750,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
@@ -3371,6 +3415,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
 
+  giscus@1.6.0:
+    dependencies:
+      lit: 3.3.3
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -3690,6 +3738,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.3
+
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.3:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.3
 
   locate-path@6.0.0:
     dependencies:


### PR DESCRIPTION
## 개요
DB 없이 댓글을 구현한다(이슈 #11 요구). **giscus**(GitHub Discussions 기반) 위젯을 포스트 상세 하단에 추가한다. 비용 0·백엔드 0·유지보수 부담 최소.

Closes #11

## 구현
- `@giscus/react` 도입, `GiscusComments` 컴포넌트 추가(`post-detail/giscus-comments.tsx`)
- 포스트 상세 푸터(추천 글 아래)에 배치
- 설정: repo `Malloc72P/Blog`(id `R_kgDON30DhA`), category **Announcements**(id `DIC_kwDON30DhM4C_oxb`), `mapping="pathname"`, `theme="light"`, `lang="ko"`, `loading="lazy"`
- Announcements 카테고리를 써서 일반 사용자는 Discussion을 직접 만들지 못하고 giscus만 생성

## ⚠️ 머지 후 필수 1회 설정 (저장소 소유자만 가능)
> 이 단계 전까지는 위젯이 "giscus is not installed on this repository"를 표시한다.
1. **giscus GitHub App 설치**: https://github.com/apps/giscus → Install → **Malloc72P/Blog** 저장소에 권한 부여
2. (이미 완료) Discussions 활성화 + `Announcements` 카테고리 — 본 작업에서 켜 둠

## 검증
- `pnpm --filter blog build` **exit 0**, `pnpm --filter blog lint` **exit 0**(회귀 0)
- 브라우저: 포스트 하단에 `<giscus-widget>`가 **정확한 설정**으로 렌더되고 `giscus.app/ko/widget?...repo=Malloc72P/Blog&category=Announcements&term=posts/frontend/ts-never-unknown&theme=light` 요청 발생 확인
- 현재는 앱 미설치라 "not installed" 단계에서 멈춤(위 1번 완료 시 완전 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
