### PR TITLE
fix(blog): JSON-LD URL 이중 슬래시 제거 및 날짜 ISO 8601 변환

### DIFF
--- a/apps/blog/src/components/post-json-ld.tsx
+++ b/apps/blog/src/components/post-json-ld.tsx
@@ -1,4 +1,5 @@
 import { Constants } from '@libs/constants';
+import { DateUtil } from '@libs/date-util';
 import { PostModel, SeriesModel } from '@libs/types/commons';
 
 interface PostJsonLdProps {
@@ -9,12 +10,17 @@ interface PostJsonLdProps {
 export function PostJsonLd({ post, series }: PostJsonLdProps) {
   const { siteConfig } = Constants;
 
+  // post.date("YYYY-MM-DD HH:mm")를 Schema.org가 기대하는 완전한 ISO 8601(타임존 오프셋 포함)로 변환한다.
+  // format은 내부에서 Asia/Seoul 타임존을 강제하므로 빌드 머신 TZ와 무관하게 결정적이다.
+  const isoDate = DateUtil.format(post.date, 'isoOffset');
+
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     headline: post.title,
-    datePublished: post.date,
-    dateModified: post.date,
+    datePublished: isoDate,
+    // 현재 frontmatter에 수정일 필드가 없어 발행일과 동일 값을 사용한다(실제 수정일 분리는 후속 과제).
+    dateModified: isoDate,
     author: {
       '@type': 'Person',
       name: 'Malloc72P',
@@ -25,7 +31,8 @@ export function PostJsonLd({ post, series }: PostJsonLdProps) {
       name: siteConfig.name,
       url: siteConfig.url,
     },
-    url: `${siteConfig.url}/${post.route}`,
+    // post.route는 이미 '/posts/...'로 시작하므로 슬래시 없이 직접 연결해 이중 슬래시를 방지한다.
+    url: `${siteConfig.url}${post.route}`,
     isPartOf: {
       '@type': 'Blog',
       name: siteConfig.title,

--- a/apps/blog/src/libs/date-util/date-format.ts
+++ b/apps/blog/src/libs/date-util/date-format.ts
@@ -1,9 +1,11 @@
-export type IDateFormat = 'long' | 'short' | 'file' | 'iso' | 'postCard';
+export type IDateFormat = 'long' | 'short' | 'file' | 'iso' | 'isoOffset' | 'postCard';
 
 export const DateFormat: Record<IDateFormat, string> = {
   long: 'YYYY. MM. DD. dddd a h시 m분',
   short: 'YYYY-MM-DD',
   file: 'YYMMDD_HHmmss',
   iso: 'YYYY-MM-DDTHH:mm',
+  // Schema.org 등 구조화 데이터가 기대하는 완전한 ISO 8601(초 + 타임존 오프셋 포함, 예: 2026-03-23T22:42:00+09:00)
+  isoOffset: 'YYYY-MM-DDTHH:mm:ssZ',
   postCard: 'YYYY. MM. DD',
 };

--- a/apps/blog/src/libs/date-util/date-util.test.ts
+++ b/apps/blog/src/libs/date-util/date-util.test.ts
@@ -10,6 +10,10 @@ describe('DateUtil.format', () => {
   it('postCard 포맷은 "YYYY. MM. DD"(분 단위 없음)', () => {
     expect(DateUtil.format('2026-06-22 22:10', 'postCard')).toBe('2026. 06. 22');
   });
+
+  it('isoOffset 포맷은 초와 타임존 오프셋(+09:00)을 포함한 ISO 8601', () => {
+    expect(DateUtil.format('2026-03-23 22:42', 'isoOffset')).toBe('2026-03-23T22:42:00+09:00');
+  });
 });
 
 describe('DateUtil.postSorter', () => {


### PR DESCRIPTION
## 개요

`PostJsonLd` 컴포넌트가 출력하는 구조화 데이터(JSON-LD)의 두 가지 SEO 문제를 수정한다.

- `url`이 `https://blog.malloc72p.com//posts/...`로 슬래시가 2개여서 canonical과 불일치
- `datePublished`/`dateModified`가 `"2026-03-23 22:42"`(공백 구분)로 Schema.org가 기대하는 ISO 8601이 아님

## 변경사항

- `post-json-ld.tsx`
  - `url`을 `${siteConfig.url}/${post.route}` → `${siteConfig.url}${post.route}`로 변경. `post.route`는 `mdx-utils.ts`에서 `/posts/${relativePath}`로 생성되어 이미 `/posts/...`로 시작하므로 슬래시를 제거하면 슬래시가 1개가 된다. (#71에서 sitemap에 적용한 패턴과 동일)
  - `datePublished`/`dateModified`를 `DateUtil.format(post.date, 'isoOffset')`로 변환해 타임존 오프셋 포함 ISO 8601로 출력
- `date-format.ts`
  - `isoOffset` 포맷(`YYYY-MM-DDTHH:mm:ssZ`)을 새로 추가. 기존 `iso`(`YYYY-MM-DDTHH:mm`)는 `toLocalTime`에서 사용 중이라 의미 변경을 피하기 위해 건드리지 않고 별도 포맷을 추가
- `date-util.test.ts`
  - `isoOffset` 포맷이 `+09:00` 오프셋을 포함하는지 검증하는 테스트 추가

`dateModified`는 현재 frontmatter에 수정일 필드가 없어 `datePublished`와 동일 값을 사용한다. 실제 수정일 분리는 frontmatter 스키마 변경이 필요해 본 PR 범위 밖이며 후속 과제로 둔다.

## 검증

- `pnpm test`: 10 suites / 39 tests 통과 (신규 isoOffset 테스트 포함)
- `pnpm lint` (`--max-warnings 0`): 통과
- `pnpm build`: 성공

JSON-LD 실측 (빌드 산출 HTML에서 `application/ld+json` 추출)

| 항목 | before | after |
| --- | --- | --- |
| `url` | `https://blog.malloc72p.com//posts/frontend/js-this` | `https://blog.malloc72p.com/posts/frontend/js-this` |
| `datePublished` | `2026-06-23 09:00` | `2026-06-23T09:00:00+09:00` |
| `dateModified` | `2026-06-23 09:00` | `2026-06-23T09:00:00+09:00` |

`DateUtil.format`은 내부에서 `Asia/Seoul` 타임존을 강제하므로 빌드 머신 TZ(`Atlantic/Reykjavik`)와 무관하게 결정적으로 `+09:00`을 출력한다.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)