### PR TITLE
fix(blog): 추천 글 postId 오타 수정 및 회귀 방지 테스트 추가

### DIFF
--- a/apps/blog/src/libs/constants.test.ts
+++ b/apps/blog/src/libs/constants.test.ts
@@ -1,0 +1,22 @@
+import { Constants } from '@libs/constants';
+import { getAllMdxFiles } from '@libs/api/mdx-utils';
+
+// 다른 api 테스트와 달리 getAllMdxFiles를 mock하지 않는다.
+// 추천 ID 오타(예: 'next-grid-app-1')처럼 실제 글과의 불일치를 잡아야 하므로
+// 실제 posts 디렉토리를 스캔한 결과(진짜 postId 집합)와 대조한다.
+describe('Constants.recommendation', () => {
+  it('모든 추천 postId가 실제 존재하는 글의 postId와 일치한다', async () => {
+    // 실제 page.mdx들을 스캔해 유효한 postId 집합을 만든다(frontMatter.id = postId).
+    const posts = await getAllMdxFiles();
+    const existingIds = new Set(
+      posts
+        .map((post) => post.frontMatter.id)
+        .filter((id): id is string => typeof id === 'string'),
+    );
+
+    // 실제 집합에 없는 추천 ID만 추려 오타/누락을 구체적으로 드러낸다.
+    const missingIds = Constants.recommendation.postIds.filter((id) => !existingIds.has(id));
+
+    expect(missingIds).toEqual([]);
+  });
+});

--- a/apps/blog/src/libs/constants.ts
+++ b/apps/blog/src/libs/constants.ts
@@ -3,7 +3,7 @@ export const Constants = {
     latestId: 'latest',
   },
   recommendation: {
-    postIds: ['ai-tool', 'sse-exam', 'next-grid-app-1', 'closure', 'execution-context'] as string[],
+    postIds: ['ai-tool', 'sse-exam', 'nextjs-grid-app-1', 'closure', 'execution-context'] as string[],
   },
   siteConfig: {
     name: 'Malloc72p.TechBlog',


### PR DESCRIPTION
## 개요

추천 글 목록에 잘못된 postId 오타가 있어 해당 글이 "함께 읽으면 좋은 글" 목록에서 조용히 누락되던 버그(#83)를 수정합니다. `post-recommendation.tsx`는 `posts.find(...)` 결과가 `undefined`면 `filter`로 제거하므로 오타가 에러 없이 묻혀 발견이 어려웠습니다.

## 변경사항

- `apps/blog/src/libs/constants.ts`: 추천 ID `'next-grid-app-1'` → 실제 postId인 `'nextjs-grid-app-1'`로 수정 (오타 1곳만 surgical 수정).
- `apps/blog/src/libs/constants.test.ts`: `Constants.recommendation.postIds`의 모든 ID가 실제 존재하는 글의 postId 집합에 포함되는지 검증하는 회귀 방지 테스트 추가. 실제 posts 디렉토리를 스캔(`getAllMdxFiles`, mock 미사용)해 오타/누락을 잡습니다.

회귀 테스트는 수정 전 `'next-grid-app-1'`을 정확히 지목하며 실패(red)했고, 수정 후 통과(green)함을 확인했습니다.

## 검증(테스트·린트·빌드 결과)

- `pnpm test`: 11 test suites, 39 tests 전부 통과
- `pnpm lint` (`--max-warnings 0`): 경고/오류 없음
- `pnpm build`: 정상 컴파일 성공 (exit 0)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)