### PR TITLE
fix(blog): 모바일 사이드바 태그 목록 잘림 및 배경 스크롤 문제 수정

### DIFF
--- a/apps/blog/src/components/mobile-sidebar.test.tsx
+++ b/apps/blog/src/components/mobile-sidebar.test.tsx
@@ -41,6 +41,21 @@ describe('MobileSidebar', () => {
     expect(document.body.style.overflow).not.toBe('hidden');
   });
 
+  it('데스크톱(md) 너비로 리사이즈되면 사이드바를 닫아 배경 스크롤 잠금을 해제한다', () => {
+    const { container } = render(<MobileSidebar seriesList={seriesList} tags={tags} />);
+
+    // 사이드바 열기 → 배경 스크롤 잠금
+    clickByIcon(container, 'tabler-icon-menu-2');
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // 뷰포트를 md(768px) 이상으로 넓히고 resize 이벤트를 발생시킨다.
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    fireEvent(window, new Event('resize'));
+
+    // 사이드바가 닫히며 배경 스크롤 잠금이 해제된다.
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
   it('태그가 많아도 모든 태그가 렌더되고, 스크롤 가능한 콘텐츠 영역에 담긴다', () => {
     const { container } = render(<MobileSidebar seriesList={seriesList} tags={tags} />);
 
@@ -49,7 +64,14 @@ describe('MobileSidebar', () => {
       expect(screen.getByText(tag.id)).toBeInTheDocument();
     });
 
-    // 콘텐츠 영역이 세로 스크롤(overflow-y-auto)을 갖는다.
-    expect(container.querySelector('.overflow-y-auto')).not.toBeNull();
+    // 콘텐츠 영역이 세로 스크롤(overflow-y-auto)을 갖고, 모든 태그가 그 안에 담겨 있다.
+    // (jsdom에는 레이아웃이 없어 실제 스크롤 동작 자체는 검증 불가하며, 구조만 보장한다.)
+    const scrollArea = container.querySelector('.overflow-y-auto');
+    expect(scrollArea).not.toBeNull();
+    // non-null assertion 대신 타입 가드로 좁힌다.
+    if (!scrollArea) throw new Error('scroll area not found');
+    tags.forEach((tag) => {
+      expect(scrollArea).toContainElement(screen.getByText(tag.id));
+    });
   });
 });

--- a/apps/blog/src/components/mobile-sidebar.test.tsx
+++ b/apps/blog/src/components/mobile-sidebar.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SeriesModel, TagModel } from '@libs/types/commons';
+import { MobileSidebar } from './mobile-sidebar';
+
+// MobileSidebar 내부에서 usePathname으로 활성 항목을 계산하므로 테스트 환경에서 고정한다.
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+// 시리즈는 동작 검증에 1개면 충분하다.
+const seriesList: SeriesModel[] = [{ id: 'frontend', title: 'Frontend', date: '2026-01-01' }];
+
+// 이슈 #101 재현: 태그가 많아 사이드바 높이를 넘기는 상황을 만든다.
+const tags: TagModel[] = Array.from({ length: 49 }, (_, index) => ({ id: `tag-${index}` }));
+
+// 비시맨틱(div) 트리거/닫기 버튼을 아이콘 클래스로 찾아 클릭한다.
+function clickByIcon(container: HTMLElement, iconClass: string) {
+  const button = container.querySelector(`.${iconClass}`)?.closest('div');
+  if (!button) throw new Error(`button not found: ${iconClass}`);
+  fireEvent.click(button);
+}
+
+describe('MobileSidebar', () => {
+  // 테스트 간 body 스타일이 누수되지 않도록 초기화한다.
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('사이드바를 열면 배경 스크롤을 잠그고, 닫으면 원래대로 복구한다', () => {
+    const { container } = render(<MobileSidebar seriesList={seriesList} tags={tags} />);
+
+    // 초기(닫힘) 상태에서는 body 스크롤을 잠그지 않는다.
+    expect(document.body.style.overflow).not.toBe('hidden');
+
+    // 사이드바 열기 → 배경 스크롤 잠금
+    clickByIcon(container, 'tabler-icon-menu-2');
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // 사이드바 닫기 → 배경 스크롤 복구
+    clickByIcon(container, 'tabler-icon-x');
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('태그가 많아도 모든 태그가 렌더되고, 스크롤 가능한 콘텐츠 영역에 담긴다', () => {
+    const { container } = render(<MobileSidebar seriesList={seriesList} tags={tags} />);
+
+    // 모든 태그가 DOM에 존재한다(잘려서 사라지지 않는다).
+    tags.forEach((tag) => {
+      expect(screen.getByText(tag.id)).toBeInTheDocument();
+    });
+
+    // 콘텐츠 영역이 세로 스크롤(overflow-y-auto)을 갖는다.
+    expect(container.querySelector('.overflow-y-auto')).not.toBeNull();
+  });
+});

--- a/apps/blog/src/components/mobile-sidebar.tsx
+++ b/apps/blog/src/components/mobile-sidebar.tsx
@@ -30,6 +30,16 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
     };
   }, [open]);
 
+  // 데스크톱(md, 768px 이상) 너비로 넓어지면 모바일 사이드바를 닫는다.
+  // 닫지 않으면 트리거가 숨겨진 채 패널이 남고, 위 스크롤 잠금도 해제되지 않는다.
+  useEffect(() => {
+    const closeOnDesktop = () => {
+      if (window.innerWidth >= 768) setOpen(false);
+    };
+    window.addEventListener('resize', closeOnDesktop);
+    return () => window.removeEventListener('resize', closeOnDesktop);
+  }, []);
+
   const onLinkClick = () => {
     setOpen(false);
   };
@@ -50,10 +60,13 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
       <div
         className={classNames(
           // 모바일 브라우저 주소창 높이를 반영하도록 100vh 대신 100dvh를 사용한다.
-          'h-[100dvh] w-full bg-white z-50 fixed top-0 right-0',
+          // md:hidden — 데스크톱 너비에서는 패널이 열린 채 남지 않도록 숨긴다.
+          'h-[100dvh] w-full bg-white z-50 fixed top-0 right-0 md:hidden',
           // 헤더는 고정하고 콘텐츠 영역만 스크롤시키기 위해 세로 flex 컬럼으로 구성한다.
           'flex flex-col',
-          'transition-all duration-300',
+          // 전이는 가로 슬라이드(transform)로 한정한다. transition-all이면 dvh 높이 변화까지
+          // 애니메이션되어 iOS 주소창 접힘 시 패널 높이가 늘었다 줄었다 하는 잔상이 생긴다.
+          'transition-transform duration-300',
           open ? 'translate-x-0' : 'translate-x-full'
         )}
       >
@@ -77,8 +90,9 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
         {/* SIDEBAR CONTENT */}
         {/* ------------------------------------------------------ */}
         {/* flex-1로 남은 높이를 모두 차지하고, 넘치는 태그 목록은 overflow-y-auto로 스크롤시킨다. */}
+        {/* overscroll-contain: 끝단에서 스크롤이 배경 문서로 전파(체이닝)되거나 iOS 러버밴딩되는 것을 막는다. */}
         {/* 마지막 항목이 화면 끝에 붙지 않도록 하단 패딩(pb-10)을 둔다. */}
-        <div className="flex-1 overflow-y-auto pt-10 pb-10 text-black px-5 space-y-10">
+        <div className="flex-1 overflow-y-auto overscroll-contain pt-10 pb-10 text-black px-5 space-y-10">
           <SidebarSection
             onClick={onLinkClick}
             title="Series"

--- a/apps/blog/src/components/mobile-sidebar.tsx
+++ b/apps/blog/src/components/mobile-sidebar.tsx
@@ -8,6 +8,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { PageLinkMap } from '@libs/page-link-map';
 import { Divider } from './divider';
+import { useBodyScrollLock } from '@hooks/use-body-scroll-lock';
 
 // MainHeaderProps와 동일한 props를 받으므로 빈 인터페이스 대신 타입 별칭으로 둔다.
 export type MobileSidebarProps = MainHeaderProps;
@@ -17,18 +18,7 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
 
   // 사이드바가 열린 동안 배경(body) 스크롤을 잠근다.
   // 잠그지 않으면 사이드바 뒤의 본문이 함께 스크롤되어 동작이 어색해진다.
-  useEffect(() => {
-    // 닫혀 있을 때는 아무 것도 하지 않고, 기존 overflow 값을 건드리지 않는다.
-    if (!open) return;
-
-    // 잠그기 직전의 overflow 값을 저장해 두었다가 닫힐 때 그대로 복구한다.
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [open]);
+  useBodyScrollLock(open);
 
   // 데스크톱(md, 768px 이상) 너비로 넓어지면 모바일 사이드바를 닫는다.
   // 닫지 않으면 트리거가 숨겨진 채 패널이 남고, 위 스크롤 잠금도 해제되지 않는다.

--- a/apps/blog/src/components/mobile-sidebar.tsx
+++ b/apps/blog/src/components/mobile-sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { MainHeaderLogo, MainHeaderProps } from './main-header';
 import { IconMenu2, IconX } from '@tabler/icons-react';
 import classNames from 'classnames';
@@ -14,6 +14,21 @@ export type MobileSidebarProps = MainHeaderProps;
 
 export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
   const [open, setOpen] = useState(false);
+
+  // 사이드바가 열린 동안 배경(body) 스크롤을 잠근다.
+  // 잠그지 않으면 사이드바 뒤의 본문이 함께 스크롤되어 동작이 어색해진다.
+  useEffect(() => {
+    // 닫혀 있을 때는 아무 것도 하지 않고, 기존 overflow 값을 건드리지 않는다.
+    if (!open) return;
+
+    // 잠그기 직전의 overflow 값을 저장해 두었다가 닫힐 때 그대로 복구한다.
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
 
   const onLinkClick = () => {
     setOpen(false);
@@ -34,7 +49,10 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
       {/* ------------------------------------------------------ */}
       <div
         className={classNames(
-          'h-[100vh] w-full bg-white z-50 fixed top-0 right-0',
+          // 모바일 브라우저 주소창 높이를 반영하도록 100vh 대신 100dvh를 사용한다.
+          'h-[100dvh] w-full bg-white z-50 fixed top-0 right-0',
+          // 헤더는 고정하고 콘텐츠 영역만 스크롤시키기 위해 세로 flex 컬럼으로 구성한다.
+          'flex flex-col',
           'transition-all duration-300',
           open ? 'translate-x-0' : 'translate-x-full'
         )}
@@ -42,7 +60,7 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
         {/* ------------------------------------------------------ */}
         {/* SIDEBAR HEADER */}
         {/* ------------------------------------------------------ */}
-        <div className="flex items-center px-5 h-[60px] bg-black">
+        <div className="flex items-center px-5 h-[60px] bg-black shrink-0">
           <MainHeaderLogo />
           <span className="grow"></span>
 
@@ -58,7 +76,9 @@ export function MobileSidebar({ seriesList, tags }: MobileSidebarProps) {
         {/* ------------------------------------------------------ */}
         {/* SIDEBAR CONTENT */}
         {/* ------------------------------------------------------ */}
-        <div className="pt-10 text-black px-5 space-y-10">
+        {/* flex-1로 남은 높이를 모두 차지하고, 넘치는 태그 목록은 overflow-y-auto로 스크롤시킨다. */}
+        {/* 마지막 항목이 화면 끝에 붙지 않도록 하단 패딩(pb-10)을 둔다. */}
+        <div className="flex-1 overflow-y-auto pt-10 pb-10 text-black px-5 space-y-10">
           <SidebarSection
             onClick={onLinkClick}
             title="Series"

--- a/apps/blog/src/components/search/search-modal.tsx
+++ b/apps/blog/src/components/search/search-modal.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearch } from './search-context';
+import { useBodyScrollLock } from '@hooks/use-body-scroll-lock';
 
 export function SearchModal() {
   const { isOpen, close, status, search } = useSearch();
@@ -19,21 +20,20 @@ export function SearchModal() {
   // 질의가 바뀔 때마다 결과 재계산(status는 콜백에서 참조하지 않아 의존성에서 제외)
   const results = useMemo(() => search(query), [search, query]);
 
-  // 모달이 열리면 입력 초기화 + 포커스, 배경 스크롤 잠금
+  // 모달이 열리면 입력 초기화 + 포커스
   useEffect(() => {
     if (!isOpen) return;
     setQuery('');
     setActiveIndex(0);
     // 렌더 직후 다음 프레임에 포커스
     const frame = window.requestAnimationFrame(() => inputRef.current?.focus());
-    // 배경 스크롤 잠금
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
     return () => {
       window.cancelAnimationFrame(frame);
-      document.body.style.overflow = prevOverflow;
     };
   }, [isOpen]);
+
+  // 모달이 열린 동안 배경 스크롤 잠금(공용 훅으로 일원화)
+  useBodyScrollLock(isOpen);
 
   // 질의가 바뀌면 활성 인덱스 초기화
   useEffect(() => {

--- a/apps/blog/src/hooks/use-body-scroll-lock.test.ts
+++ b/apps/blog/src/hooks/use-body-scroll-lock.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import { useBodyScrollLock } from './use-body-scroll-lock';
+
+describe('useBodyScrollLock', () => {
+  // 모듈 단위 카운트가 다른 테스트로 누수되지 않도록 body 스타일을 초기화한다.
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  it('locked=false면 body 스크롤을 잠그지 않는다', () => {
+    renderHook(() => useBodyScrollLock(false));
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('locked=true면 잠그고, 해제(언마운트)되면 원래 값으로 복구한다', () => {
+    const { unmount } = renderHook(() => useBodyScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+
+  it('잠그기 직전의 overflow 값을 정확히 복구한다', () => {
+    // 기본값('')이 아닌 값으로 시작해도 그대로 되돌려야 한다.
+    document.body.style.overflow = 'scroll';
+
+    const { unmount } = renderHook(() => useBodyScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    unmount();
+    expect(document.body.style.overflow).toBe('scroll');
+  });
+
+  it('두 소비자가 동시에 잠그면 마지막 하나가 풀릴 때까지 잠금을 유지한다(참조 카운트)', () => {
+    const first = renderHook(() => useBodyScrollLock(true));
+    const second = renderHook(() => useBodyScrollLock(true));
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // 하나만 해제 → 아직 다른 소비자가 잠금을 요구하므로 유지된다.
+    first.unmount();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // 마지막 소비자까지 해제 → 비로소 복구된다.
+    second.unmount();
+    expect(document.body.style.overflow).not.toBe('hidden');
+  });
+});

--- a/apps/blog/src/hooks/use-body-scroll-lock.ts
+++ b/apps/blog/src/hooks/use-body-scroll-lock.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+// 사이드바·검색 모달 등 여러 오버레이가 각각 배경 스크롤을 잠그려 할 수 있다.
+// 단순히 컴포넌트마다 overflow를 저장/복구하면 마지막에 닫힌 쪽이 다른 오버레이의
+// 잠금까지 해제해버릴 수 있으므로, 모듈 단위 참조 카운트로 일원화한다.
+let lockCount = 0;
+// 최초로 잠그기 직전의 overflow 값. 마지막 잠금이 풀릴 때 이 값으로 복구한다.
+let previousOverflow = '';
+
+/**
+ * locked가 true인 동안 document.body 스크롤을 잠근다.
+ * 여러 컴포넌트가 동시에 호출해도 참조 카운트로 안전하게 동작하며,
+ * 잠금 요청이 하나라도 남아 있으면 잠금을 유지하고 마지막 해제 시 원래 값으로 되돌린다.
+ */
+export function useBodyScrollLock(locked: boolean) {
+  useEffect(() => {
+    // 잠그지 않을 때는 카운트를 건드리지 않는다.
+    if (!locked) return;
+
+    // 0 -> 1, 즉 처음 잠그는 순간에만 원래 overflow를 저장하고 hidden으로 바꾼다.
+    if (lockCount === 0) {
+      previousOverflow = document.body.style.overflow;
+      document.body.style.overflow = 'hidden';
+    }
+    lockCount += 1;
+
+    return () => {
+      lockCount -= 1;
+      // 마지막 잠금이 풀리는 순간에만 원래 값으로 복구한다.
+      if (lockCount === 0) {
+        document.body.style.overflow = previousOverflow;
+      }
+    };
+  }, [locked]);
+}


### PR DESCRIPTION
## 개요

[#101](https://github.com/Malloc72P/Blog/issues/101) 모바일 사이드바 버그를 수정한다. 태그가 49개로 늘면서 사이드바 콘텐츠가 뷰포트 높이를 넘겨 다음 문제가 발생했다.

1. 태그 컨테이너가 화면보다 커져 아래쪽 태그가 잘려서 보이지 않음
2. 잘린 영역을 스크롤로 볼 수 없음
3. 사이드바가 열린 상태에서 배경(body) 스크롤이 그대로 반응해 동작이 어색함

## 변경 사항

- **콘텐츠 스크롤**: 사이드바를 `flex flex-col`로 구성하고, 헤더는 `shrink-0`으로 고정, 콘텐츠 영역은 `flex-1 overflow-y-auto`로 남은 높이를 차지하며 스크롤되게 함. 마지막 항목이 끝에 붙지 않도록 `pb-10` 추가.
- **배경 스크롤 잠금**: 사이드바가 열린 동안 `document.body`의 스크롤을 잠그고, 닫히거나 언마운트될 때 직전 값으로 복구하는 `useEffect` 추가.
- **모바일 뷰포트**: `100vh` → `100dvh`로 변경해 모바일 브라우저 주소창 높이를 반영.
- **회귀 테스트**: `mobile-sidebar.test.tsx` 추가 — (1) 열림/닫힘 시 배경 스크롤 잠금/복구, (2) 태그 49개가 모두 렌더되고 스크롤 컨테이너에 담기는지 검증.

## 검증

- `pnpm test` — 12 suites / 42 tests 통과
- `pnpm lint` — 통과 (max-warnings 0)
- `pnpm build` — 컴파일 성공

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)