### PR TITLE
feat(blog): 랜딩 헤딩 위계·skip 링크·reduced-motion 대응 (#88)

### DIFF
--- a/apps/blog/src/app/(main)/main-client-layout.tsx
+++ b/apps/blog/src/app/(main)/main-client-layout.tsx
@@ -47,6 +47,15 @@ export default function MainClientLayout({
       {/* 검색 컨텍스트로 헤더 버튼과 모달이 상태를 공유한다 */}
       <SearchProvider>
         <div className="blog-main-layout h-full">
+          {/* 키보드 사용자가 헤더 내비를 건너뛰고 본문으로 바로 이동할 수 있는 skip 링크.
+              평소엔 sr-only로 숨기고 포커스되면 좌상단에 노출한다. */}
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded focus:bg-black focus:px-4 focus:py-2 focus:text-white"
+          >
+            본문으로 건너뛰기
+          </a>
+
           {/* ------------------------------------------------------ */}
           {/* HEADER */}
           {/* ------------------------------------------------------ */}

--- a/apps/blog/src/app/(main)/main-client-layout.tsx
+++ b/apps/blog/src/app/(main)/main-client-layout.tsx
@@ -3,6 +3,7 @@
 import { MainFooter } from '@components/main-footer';
 import { MainHeader } from '@components/main-header';
 import { SearchModal, SearchProvider } from '@components/search';
+import { Constants } from '@libs/constants';
 import { PostModel, SeriesModel, TagModel } from '@libs/types/commons';
 import { createContext, PropsWithChildren, useMemo } from 'react';
 
@@ -50,7 +51,7 @@ export default function MainClientLayout({
           {/* 키보드 사용자가 헤더 내비를 건너뛰고 본문으로 바로 이동할 수 있는 skip 링크.
               평소엔 sr-only로 숨기고 포커스되면 좌상단에 노출한다. */}
           <a
-            href="#main-content"
+            href={`#${Constants.a11y.mainContentId}`}
             className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:rounded focus:bg-black focus:px-4 focus:py-2 focus:text-white"
           >
             본문으로 건너뛰기

--- a/apps/blog/src/app/(main)/main-client-page.tsx
+++ b/apps/blog/src/app/(main)/main-client-page.tsx
@@ -97,6 +97,9 @@ export function MainClientPage({ seriesPosts }: MainClientPageProps) {
   return (
     <ArticleContainer>
       <div className="blog-landing-page pb-[10rem] max-w-[700px] mx-auto">
+        {/* 시각적으로는 소개 카드가 첫 화면을 차지하지만, 문서/스크린리더에는 페이지 제목 h1이 필요하다. */}
+        <h1 className="sr-only">Malloc72P 기술 블로그</h1>
+
         {/* ------------------------------------------------------ */}
         {/* INTRODUCE CARD */}
         {/* ------------------------------------------------------ */}

--- a/apps/blog/src/app/global.css
+++ b/apps/blog/src/app/global.css
@@ -4,3 +4,16 @@ html,
 body {
   height: 100%;
 }
+
+/* 동작 줄이기(prefers-reduced-motion) 설정 시 전역 트랜지션/애니메이션/부드러운 스크롤을 사실상 비활성화한다.
+   어지럼증(전정기관 장애) 사용자를 위한 WCAG 2.3.3 대응. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/apps/blog/src/components/article-container.test.tsx
+++ b/apps/blog/src/components/article-container.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react';
+import { Constants } from '@libs/constants';
+import { ArticleContainer } from './article-container';
+
+describe('ArticleContainer', () => {
+  it('skip 링크 타깃이 되도록 main에 공유 id와 tabIndex=-1을 부여한다', () => {
+    const { container } = render(<ArticleContainer>본문</ArticleContainer>);
+
+    const main = container.querySelector('main');
+    expect(main).not.toBeNull();
+    if (!main) throw new Error('main not found');
+
+    // skip 링크 href와 동일한 공유 상수를 사용해 앵커 계약이 어긋나지 않도록 한다.
+    expect(main).toHaveAttribute('id', Constants.a11y.mainContentId);
+    expect(main).toHaveAttribute('tabindex', '-1');
+  });
+});

--- a/apps/blog/src/components/article-container.tsx
+++ b/apps/blog/src/components/article-container.tsx
@@ -7,7 +7,12 @@ export interface ArticleContainerProps extends PropsWithChildren {
 
 export function ArticleContainer({ children, right, jsonLd }: ArticleContainerProps) {
   return (
-    <main className="article-container relative z-10 min-h-[100vh] bg-white flex">
+    <main
+      // skip 링크(본문 바로가기)의 이동 대상. tabIndex=-1로 프로그램적 포커스를 받을 수 있게 한다.
+      id="main-content"
+      tabIndex={-1}
+      className="article-container relative z-10 min-h-[100vh] bg-white flex outline-none"
+    >
       {jsonLd}
       <div className="grow basis-0 relative"></div>
       <div className="max-w-[1024px] w-full px-5 sm:px-10">{children}</div>

--- a/apps/blog/src/components/article-container.tsx
+++ b/apps/blog/src/components/article-container.tsx
@@ -1,3 +1,4 @@
+import { Constants } from '@libs/constants';
 import { PropsWithChildren, ReactElement } from 'react';
 
 export interface ArticleContainerProps extends PropsWithChildren {
@@ -9,7 +10,7 @@ export function ArticleContainer({ children, right, jsonLd }: ArticleContainerPr
   return (
     <main
       // skip 링크(본문 바로가기)의 이동 대상. tabIndex=-1로 프로그램적 포커스를 받을 수 있게 한다.
-      id="main-content"
+      id={Constants.a11y.mainContentId}
       tabIndex={-1}
       className="article-container relative z-10 min-h-[100vh] bg-white flex outline-none"
     >

--- a/apps/blog/src/components/main-footer.tsx
+++ b/apps/blog/src/components/main-footer.tsx
@@ -32,7 +32,9 @@ export function MainFooter({ seriesList }: MainFooterProps) {
               color="primary"
               leftIcon={IconArrowUp}
               onClick={() => {
-                window.scrollTo({ top: 0, behavior: 'smooth' });
+                // 동작 줄이기 설정 시 즉시 이동한다(JS 스크롤은 CSS scroll-behavior의 영향을 받지 않으므로 별도 분기).
+                const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                window.scrollTo({ top: 0, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
               }}
             >
               <span>Back to top</span>

--- a/apps/blog/src/components/post-card.test.tsx
+++ b/apps/blog/src/components/post-card.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { PostCard } from './post-card';
+import { PostModel, SeriesModel } from '@libs/types/commons';
+
+// PostCard는 useRouter로 카드 클릭 이동을 처리하므로 테스트 환경에서 모킹한다.
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const series: SeriesModel = { id: 'frontend', title: 'Frontend', date: '2026-01-01' };
+const post: PostModel = {
+  id: 'my-post',
+  route: '/posts/frontend/my-post',
+  series,
+  title: '내 포스트 제목',
+  tags: [{ id: 'react' }],
+  date: '2026-01-02 10:00',
+};
+
+describe('PostCard', () => {
+  it('포스트 제목을 레벨 2 헤딩(h2)으로 렌더한다(헤딩 위계/스크린리더 탐색)', () => {
+    render(<PostCard post={post} series={series} />);
+
+    expect(screen.getByRole('heading', { level: 2, name: '내 포스트 제목' })).toBeInTheDocument();
+  });
+});

--- a/apps/blog/src/components/post-card.test.tsx
+++ b/apps/blog/src/components/post-card.test.tsx
@@ -18,9 +18,12 @@ const post: PostModel = {
 };
 
 describe('PostCard', () => {
-  it('포스트 제목을 레벨 2 헤딩(h2)으로 렌더한다(헤딩 위계/스크린리더 탐색)', () => {
+  it('포스트 제목을 레벨 2 헤딩(h2)으로 렌더하며, 제목 링크 안에 위치한다', () => {
     render(<PostCard post={post} series={series} />);
 
-    expect(screen.getByRole('heading', { level: 2, name: '내 포스트 제목' })).toBeInTheDocument();
+    const heading = screen.getByRole('heading', { level: 2, name: '내 포스트 제목' });
+    expect(heading).toBeInTheDocument();
+    // 제목은 헤딩이면서 동시에 글로 이동하는 링크여야 한다.
+    expect(heading.closest('a')).toHaveAttribute('href', post.route);
   });
 });

--- a/apps/blog/src/components/post-card.tsx
+++ b/apps/blog/src/components/post-card.tsx
@@ -40,8 +40,9 @@ export function PostCard({ post, showSeriesBadge = true }: PostCardProps) {
       {/* === POST TITLE AND LINK === */}
       {/* 제목 Link는 키보드 포커스/새 탭 열기 등 접근성을 위해 실제 <a>로 유지한다. */}
       <Link href={post.route}>
-        {/* 모바일 제목을 키워 태그(배지)와 위계를 확보한다. */}
-        <span className="text-sm md:text-lg font-bold">{post.title}</span>
+        {/* 목록의 각 글 제목은 문서 구조상 h2다(스크린리더 헤딩 탐색·SEO 위계).
+            모바일 제목을 키워 태그(배지)와 위계를 확보한다. */}
+        <h2 className="text-sm md:text-lg font-bold">{post.title}</h2>
       </Link>
 
       {/* 목록에서는 분/시 없이 날짜만 노출한다(date-format의 postCard 패턴 사용). */}

--- a/apps/blog/src/libs/constants.ts
+++ b/apps/blog/src/libs/constants.ts
@@ -2,6 +2,10 @@ export const Constants = {
   series: {
     latestId: 'latest',
   },
+  a11y: {
+    // skip 링크(본문 바로가기)와 <main> 타깃을 잇는 앵커 id. 두 파일이 같은 값을 공유하도록 단일화한다.
+    mainContentId: 'main-content',
+  },
   recommendation: {
     postIds: ['ai-tool', 'sse-exam', 'nextjs-grid-app-1', 'closure', 'execution-context'] as string[],
   },


### PR DESCRIPTION
## 개요

[#88](https://github.com/Malloc72P/Blog/issues/88) — 랜딩의 헤딩 위계 부재, 본문 바로가기(skip) 링크 부재, `prefers-reduced-motion` 미대응을 해결한다.

## 변경 사항

### 헤딩 위계 (WCAG 1.3.1 / 2.4.6)
- 랜딩(`main-client-page.tsx`)에 `sr-only` `<h1>` 추가 — 시각 디자인은 그대로 두고 문서/스크린리더에 페이지 제목 제공
- 포스트 카드 제목(`post-card.tsx`) `<span>` → `<h2>` 승격
  - 시리즈/태그 상세는 `ArticleHeader`가 `<h1>`을 제공하므로 `h1 → h2` 위계가 정합 (Tailwind preflight로 시각 변화 없음)

### Skip 링크 (WCAG 2.4.1)
- `main-client-layout.tsx` 최상단에 "본문으로 건너뛰기" 링크 추가 (`sr-only` → 포커스 시 좌상단 노출)
- `ArticleContainer`의 `<main>`에 `id="main-content"` + `tabIndex={-1}` 타깃 부여

### Reduced motion (WCAG 2.3.3)
- `global.css`에 `@media (prefers-reduced-motion: reduce)` 분기 추가 — 전역 트랜지션/애니메이션/스무스 스크롤 사실상 비활성화

## 검증
- `pnpm test` — 15 suites / 57 tests 통과 (PostCard h2 회귀 테스트 신설)
- `pnpm lint` — 클린 / `pnpm build` — 성공

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)