### PR TITLE
perf(blog): 신택스 하이라이터 클라이언트 번들 제거 (#96)

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -6,6 +6,22 @@ import createMDX from '@next/mdx';
 const withMDX = createMDX({
   options: {
     remarkPlugins: ['remark-gfm'],
+    // 신택스 하이라이팅을 빌드타임에 shiki로 처리해 클라이언트 하이라이터 JS를 0으로 만든다.
+    // @next/mdx + Turbopack은 플러그인을 직렬화하므로 [모듈명, 옵션] 배열 형태로 전달한다.
+    rehypePlugins: [
+      [
+        'rehype-pretty-code',
+        {
+          // 기존 darcula 다크 테마를 대체할 적절한 다크 테마.
+          theme: 'github-dark',
+          // 테마의 배경색을 유지해 기존 다크 코드블록 톤을 보존한다.
+          keepBackground: true,
+          // 언어를 명시하지 않은 코드블록도 동일하게 grid/라인 처리되도록 기본 언어를 지정한다.
+          // (이전 Prism 구현은 모든 블록에 라인넘버를 붙였으므로 그 동작을 보존한다.)
+          defaultLang: 'text',
+        },
+      ],
+    ],
   },
 });
 

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -26,8 +26,9 @@
     "next": "^16.2.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-syntax-highlighter": "^16.1.1",
-    "remark-gfm": "^4.0.1"
+    "rehype-pretty-code": "^0.14.3",
+    "remark-gfm": "^4.0.1",
+    "shiki": "^4.3.0"
   },
   "devDependencies": {
     "@next/mdx": "^16.2.1",
@@ -42,7 +43,6 @@
     "@types/node": "22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@types/react-syntax-highlighter": "^15.5.13",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "tailwindcss": "^4",

--- a/apps/blog/src/components/post-detail/copy-button.tsx
+++ b/apps/blog/src/components/post-detail/copy-button.tsx
@@ -6,7 +6,8 @@ import classes from './post-detail.module.scss';
 import classNames from 'classnames';
 
 export interface CopyButtonProps {
-  content: string;
+  // 복사 시점에 코드 원문을 읽어오는 함수. 빌드타임 하이라이팅에선 pre의 textContent에서 읽으므로 함수로 받는다.
+  getContent: () => string;
 }
 
 /**
@@ -24,14 +25,14 @@ export interface CopyButtonProps {
  * 이렇게 하면 PostCodeBlock은 서버 컴포넌트처럼 취급되더라도, 자식 컴포넌트는 정상적으로 클라이언트 사이드에서 처리된다.
  *
  */
-export function CopyButton({ content }: CopyButtonProps) {
+export function CopyButton({ getContent }: CopyButtonProps) {
   // 복사 성공 여부를 상태로 관리해 클릭 후 일정 시간 체크 아이콘으로 피드백한다.
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     // 클립보드 쓰기에 실패해도 화면이 깨지지 않도록 예외를 흡수한다.
     try {
-      await navigator.clipboard.writeText(content);
+      await navigator.clipboard.writeText(getContent());
       setCopied(true);
       // 1.5초 뒤 원래 복사 아이콘으로 되돌린다.
       setTimeout(() => setCopied(false), 1500);

--- a/apps/blog/src/components/post-detail/post-codeblock-client.tsx
+++ b/apps/blog/src/components/post-detail/post-codeblock-client.tsx
@@ -1,21 +1,31 @@
 'use client';
 
-import { Prism } from 'react-syntax-highlighter';
-import { darcula } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { ComponentPropsWithoutRef, useRef } from 'react';
 import { CopyButton } from './copy-button';
 
-interface PostCodeblockClientProps {
-  language: string;
-  code: string;
-}
+// rehype-pretty-code가 빌드타임에 하이라이팅한 <pre>를 그대로 받기 위해 기본 pre 속성을 모두 허용한다.
+export type PostCodeblockClientProps = ComponentPropsWithoutRef<'pre'>;
 
-export function PostCodeblockClient({ language, code }: PostCodeblockClientProps) {
+/**
+ * 빌드타임(shiki)에 하이라이팅된 <pre> 마크업을 그대로 렌더하고,
+ * 우상단에 복사 버튼을 오버레이하는 클라이언트 래퍼.
+ * 복사 원문은 pre의 textContent에서 읽으므로 별도로 코드 문자열을 prop으로 받지 않는다.
+ * (라인넘버는 CSS ::before 카운터라 textContent에 포함되지 않는다.)
+ */
+export function PostCodeblockClient({ children, ...preProps }: PostCodeblockClientProps) {
+  // 복사 시 원문 텍스트를 읽어올 대상 pre 엘리먼트 참조.
+  const preRef = useRef<HTMLPreElement>(null);
+
+  // 클립보드에 넣을 코드 원문을 pre의 textContent에서 가져온다.
+  const getCode = () => preRef.current?.textContent ?? '';
+
   return (
     <div className="blog-code relative">
-      <Prism language={language} showLineNumbers style={darcula}>
-        {code}
-      </Prism>
-      <CopyButton content={code} />
+      {/* rehype-pretty-code가 주입한 data-* 속성과 인라인 배경 스타일을 그대로 전달한다. */}
+      <pre ref={preRef} {...preProps}>
+        {children}
+      </pre>
+      <CopyButton getContent={getCode} />
     </div>
   );
 }

--- a/apps/blog/src/components/post-detail/post-codeblock.tsx
+++ b/apps/blog/src/components/post-detail/post-codeblock.tsx
@@ -1,15 +1,10 @@
-import React, { PropsWithChildren } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 import { PostCodeblockClient } from './post-codeblock-client';
 
-// children만 받으므로 빈 인터페이스 대신 타입 별칭으로 둔다.
-export type PostCodeblockProps = PropsWithChildren;
+// MDX의 pre 매핑 컴포넌트. rehype-pretty-code가 하이라이팅한 pre 속성을 그대로 받는다.
+export type PostCodeblockProps = ComponentPropsWithoutRef<'pre'>;
 
 export function PostCodeblock(props: PostCodeblockProps) {
-  const { children } = props;
-  const codeProps = (children as React.ReactElement<{ className?: string; children?: string }>)?.props;
-
-  const language = codeProps?.className?.replace('language-', '') ?? '';
-  const code = codeProps?.children ?? '';
-
-  return <PostCodeblockClient language={language} code={code} />;
+  // 복사 버튼은 이벤트 핸들러가 필요해 별도 클라이언트 컴포넌트로 분리한다(copy-button.tsx 주석 참고).
+  return <PostCodeblockClient {...props} />;
 }

--- a/apps/blog/src/components/post-detail/post-detail.module.scss
+++ b/apps/blog/src/components/post-detail/post-detail.module.scss
@@ -62,14 +62,11 @@
     box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   }
 
-  pre {
-    border-radius: 8px;
-  }
-
   // === shiki(rehype-pretty-code) 빌드타임 하이라이팅 코드블록 ===
   // 이전 Prism 구현이 인라인으로 주던 패딩/스크롤/라인넘버를 CSS로 대체한다.
   // 배경색·문법 색은 shiki가 pre/span에 인라인 style로 주입한다.
   pre {
+    border-radius: 8px;
     // 가로로 긴 코드는 잘리지 않고 스크롤되도록 한다.
     overflow-x: auto;
     // Prism 기본 패딩과 유사한 여백을 코드 영역에 준다(복사 버튼과 겹치지 않도록 우측은 본문 패딩으로 충분).
@@ -184,9 +181,16 @@
     }
 
     // ```로 감싸진 코드 블록
+    // 가로 패딩은 데스크탑과 동일하게 [data-line]이 담당하므로 pre는 세로 패딩만 둔다.
+    // (과거 Prism 인라인 스타일을 덮으려던 !important / 가로 12px 잔재 제거)
     pre {
-      padding: 16px 12px !important;
+      padding: 16px 0;
       font-size: 14px; // 모바일에서 코드 한 줄 노출량/가독성 개선을 위해 12px에서 14px로 상향
+
+      // 좁은 화면에선 코드 본문 가로 들여쓰기를 12px로 줄여 한 줄 노출량을 늘린다.
+      [data-line] {
+        padding: 0 12px;
+      }
     }
 
     table {

--- a/apps/blog/src/components/post-detail/post-detail.module.scss
+++ b/apps/blog/src/components/post-detail/post-detail.module.scss
@@ -66,6 +66,39 @@
     border-radius: 8px;
   }
 
+  // === shiki(rehype-pretty-code) 빌드타임 하이라이팅 코드블록 ===
+  // 이전 Prism 구현이 인라인으로 주던 패딩/스크롤/라인넘버를 CSS로 대체한다.
+  // 배경색·문법 색은 shiki가 pre/span에 인라인 style로 주입한다.
+  pre {
+    // 가로로 긴 코드는 잘리지 않고 스크롤되도록 한다.
+    overflow-x: auto;
+    // Prism 기본 패딩과 유사한 여백을 코드 영역에 준다(복사 버튼과 겹치지 않도록 우측은 본문 패딩으로 충분).
+    padding: 16px 0;
+    line-height: 1.6;
+
+    code {
+      display: grid; // shiki가 인라인으로도 주지만 라인 단위 grid 레이아웃을 보장한다.
+      counter-reset: line; // 라인넘버 카운터를 코드블록 단위로 초기화한다.
+    }
+
+    // 각 코드 라인. 좌우 패딩으로 코드 본문을 들여쓴다.
+    [data-line] {
+      padding: 0 16px;
+    }
+
+    // 라인넘버: data-line 라인마다 카운터를 증가시켜 ::before로 표시한다.
+    [data-line]::before {
+      counter-increment: line;
+      content: counter(line);
+      display: inline-block;
+      width: 1.2rem;
+      margin-right: 16px;
+      text-align: right;
+      // 코드 텍스트와 구분되도록 흐린 색으로 라인넘버를 표시한다.
+      color: rgba(255, 255, 255, 0.35);
+    }
+  }
+
   table {
     width: 100%;
     margin: 16px 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,12 +56,15 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
-      react-syntax-highlighter:
-        specifier: ^16.1.1
-        version: 16.1.1(react@19.2.4)
+      rehype-pretty-code:
+        specifier: ^0.14.3
+        version: 0.14.3(shiki@4.3.0)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      shiki:
+        specifier: ^4.3.0
+        version: 4.3.0
     devDependencies:
       '@next/mdx':
         specifier: ^16.2.1
@@ -99,9 +102,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
-      '@types/react-syntax-highlighter':
-        specifier: ^15.5.13
-        version: 15.5.13
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@22.19.15)
@@ -911,6 +911,37 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  '@shikijs/core@4.3.0':
+    resolution: {integrity: sha512-EooU3i9F6IAE8kEu+AnGf9DFZWkQBZ+hJn3tLVbsH+61mtQiva5biai66fAA6nvFPXkLgvrh7BrR7YcJU83xQQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.3.0':
+    resolution: {integrity: sha512-hTv/KiFf2tpiqlACPiztGGurEARWIutB8YUhcrA1pUC7VzzwKO+g5crUocrLztrZ5ro5Z4hbXg7bYclETn3gSQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.3.0':
+    resolution: {integrity: sha512-1vMdN3gHfnKfLYwecUI2ITJI4RhHt96xEaJumVn7Heb0IlJ8WQMIH0Voak+2j22BpSNKdnOfB/pCTPnPm2gq7A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.3.0':
+    resolution: {integrity: sha512-rnlqFbBRSys9bT4gl/5rw9RnS0W/I84ZldXPkO7cvlEMoV85TyF/aU01N7/NbSR776RNLjrJKjfFUXJR6wN1Cg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.3.0':
+    resolution: {integrity: sha512-CPkz64PTa5diRW1ggzMZH9VM/du4RNChYgVtgqrFcgruvIybmCvySv8GkiHSczUHXYuuR8TdKEwFx+UnZMpgdg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.3.0':
+    resolution: {integrity: sha512-Avgt05YiT+Y3prjIc9lmQxhJzHBcCfR6cjiFW4OyaMBbt2A6trX5rfjUzx+Vj/mE9qpArYjatnqo9XPjQNW/AQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.3.0':
+    resolution: {integrity: sha512-oc8b9U2SYvofKZk8e/737nIX0qwf6eV2vHFATeObAu7r+mUVpLs8Re0BmVkIjAWAYgkmG/CzLNo7rzuBzRu/wQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
@@ -1102,16 +1133,10 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
-  '@types/prismjs@1.26.6':
-    resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
-
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
-
-  '@types/react-syntax-highlighter@15.5.13':
-    resolution: {integrity: sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -1938,9 +1963,6 @@ packages:
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
-  fault@1.0.4:
-    resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
-
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
@@ -1973,10 +1995,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  format@0.2.2:
-    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
-    engines: {node: '>=0.4.x'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -2091,14 +2109,26 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
@@ -2106,18 +2136,15 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  highlight.js@10.7.3:
-    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
-
-  highlightjs-vue@1.0.0:
-    resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
-
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -2634,9 +2661,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lowlight@1.20.0:
-    resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
-
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2945,6 +2969,12 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2982,6 +3012,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-numeric-range@1.3.0:
+    resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -3052,10 +3085,6 @@ packages:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  prismjs@1.30.0:
-    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
-    engines: {node: '>=6'}
-
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3089,12 +3118,6 @@ packages:
   react-is@19.2.7:
     resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
-  react-syntax-highlighter@16.1.1:
-    resolution: {integrity: sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==}
-    engines: {node: '>= 16.20.2'}
-    peerDependencies:
-      react: '>= 0.14.0'
-
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -3125,12 +3148,27 @@ packages:
     resolution: {integrity: sha512-fmfw4XgoDke3kdI6h4xcUz1dG8uaiv5q9gcEwLS4Pnth2kxT+GZ7YehS1JTMGBQmtV7Y4GFGbs2re2NqhdozUg==}
     engines: {node: '>= 0.4'}
 
-  refractor@5.0.0:
-    resolution: {integrity: sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==}
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   regexp.prototype.flags@1.5.3:
     resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-pretty-code@0.14.3:
+    resolution: {integrity: sha512-Cz692FeYusTjT5cfFWLc4r7JhgC3/JlJptgUh4iffBxWxUnWW1oqbWFi7jGCeq00DYUm8yzoTnvpocaYa5x82g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      shiki: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
@@ -3233,6 +3271,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@4.3.0:
+    resolution: {integrity: sha512-NKKjWzR6LIGL3sXBrWDw9sDS9cxx42/DkysaNqJEeOWE8Kix5gpak0bc00OfDVEO4oyXSyz8+aRaqKoBD1yo7A==}
+    engines: {node: '>=20'}
 
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
@@ -3537,6 +3579,9 @@ packages:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -3549,6 +3594,9 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -4462,6 +4510,46 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@shikijs/core@4.3.0':
+    dependencies:
+      '@shikijs/primitive': 4.3.0
+      '@shikijs/types': 4.3.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.3.0':
+    dependencies:
+      '@shikijs/types': 4.3.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.3.0':
+    dependencies:
+      '@shikijs/types': 4.3.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.3.0':
+    dependencies:
+      '@shikijs/types': 4.3.0
+
+  '@shikijs/primitive@4.3.0':
+    dependencies:
+      '@shikijs/types': 4.3.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.3.0':
+    dependencies:
+      '@shikijs/types': 4.3.0
+
+  '@shikijs/types@4.3.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sinclair/typebox@0.34.49': {}
 
   '@sinonjs/commons@3.0.1':
@@ -4622,7 +4710,7 @@ snapshots:
 
   '@types/hast@3.0.4':
     dependencies:
-      '@types/unist': 2.0.11
+      '@types/unist': 3.0.3
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -4659,13 +4747,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/prismjs@1.26.6': {}
-
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
-
-  '@types/react-syntax-highlighter@15.5.13':
     dependencies:
       '@types/react': 19.2.14
 
@@ -5550,10 +5632,6 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fault@1.0.4:
-    dependencies:
-      format: 0.2.2
-
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
@@ -5591,8 +5669,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  format@0.2.2: {}
 
   fs.realpath@1.0.0: {}
 
@@ -5701,6 +5777,26 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.1.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
   hast-util-parse-selector@4.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -5726,6 +5822,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.6
@@ -5746,6 +5856,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -5758,15 +5872,13 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  highlight.js@10.7.3: {}
-
-  highlightjs-vue@1.0.0: {}
-
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-void-elements@3.0.0: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -6458,11 +6570,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lowlight@1.20.0:
-    dependencies:
-      fault: 1.0.4
-      highlight.js: 10.7.3
-
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -7027,6 +7134,14 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -7076,6 +7191,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-numeric-range@1.3.0: {}
 
   parse5@7.3.0:
     dependencies:
@@ -7137,8 +7254,6 @@ snapshots:
       react-is-18: react-is@18.3.1
       react-is-19: react-is@19.2.7
 
-  prismjs@1.30.0: {}
-
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -7165,16 +7280,6 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.7: {}
-
-  react-syntax-highlighter@16.1.1(react@19.2.4):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      highlight.js: 10.7.3
-      highlightjs-vue: 1.0.0
-      lowlight: 1.20.0
-      prismjs: 1.30.0
-      react: 19.2.4
-      refractor: 5.0.0
 
   react@19.2.4: {}
 
@@ -7225,12 +7330,15 @@ snapshots:
       globalthis: 1.0.4
       which-builtin-type: 1.1.4
 
-  refractor@5.0.0:
+  regex-recursion@6.0.2:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/prismjs': 1.26.6
-      hastscript: 9.0.1
-      parse-entities: 4.0.2
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   regexp.prototype.flags@1.5.3:
     dependencies:
@@ -7238,6 +7346,22 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-pretty-code@0.14.3(shiki@4.3.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-string: 3.0.1
+      parse-numeric-range: 1.3.0
+      rehype-parse: 9.0.1
+      shiki: 4.3.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
 
   rehype-recma@1.0.0:
     dependencies:
@@ -7401,6 +7525,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@4.3.0:
+    dependencies:
+      '@shikijs/core': 4.3.0
+      '@shikijs/engine-javascript': 4.3.0
+      '@shikijs/engine-oniguruma': 4.3.0
+      '@shikijs/langs': 4.3.0
+      '@shikijs/themes': 4.3.0
+      '@shikijs/types': 4.3.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel@1.0.6:
     dependencies:
@@ -7754,6 +7889,11 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -7771,6 +7911,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-namespaces@2.0.1: {}
 
   webidl-conversions@7.0.0: {}
 


### PR DESCRIPTION
## 배경

`post-codeblock-client.tsx`가 `'use client'`로 `react-syntax-highlighter`의 Prism(darcula)을 사용했다. 전 언어 register 때문에 단일 **648KB 청크**가 모든 포스트의 First Load JS에 실렸다. 하이라이팅 결과는 이미 SSG로 서버 HTML에 렌더되는데, 같은 거대 JS가 하이드레이션용으로 또 전송되는 낭비였다.

## 택한 접근: rehype-pretty-code(shiki) 빌드타임 하이라이팅

이슈의 선호안인 **shiki 빌드타임 전환**을 채택했다. 복사 버튼/라인넘버/다크 테마를 합리적 범위 내에서 유지할 수 있어 폴백(PrismAsyncLight)으로 내려가지 않았다.

- `next.config.mjs`의 createMDX `options.rehypePlugins`에 `[['rehype-pretty-code', { theme: 'github-dark', keepBackground: true, defaultLang: 'text' }]]` 추가. @next/mdx + Turbopack의 플러그인 직렬화(문자열/배열) 형식을 사용했다.
- 하이라이팅이 빌드타임에 끝나므로 **클라이언트 하이라이터 JS는 0**이다.

## 변경 파일

- `apps/blog/next.config.mjs` — rehype-pretty-code 플러그인 추가
- `apps/blog/package.json` — `react-syntax-highlighter`/`@types/react-syntax-highlighter` 제거, `rehype-pretty-code`/`shiki` 추가
- `apps/blog/src/components/post-detail/post-codeblock.tsx` — pre 매핑을 하이라이팅된 마크업 패스스루로 재작성
- `apps/blog/src/components/post-detail/post-codeblock-client.tsx` — `<pre>`를 그대로 렌더하고 복사 버튼 오버레이, 복사 원문은 `preRef.textContent`로 읽음
- `apps/blog/src/components/post-detail/copy-button.tsx` — `content: string` → `getContent: () => string` (동작/스타일은 그대로)
- `apps/blog/src/components/post-detail/post-detail.module.scss` — 라인넘버(`[data-line]` CSS 카운터)·패딩·가로 스크롤 CSS 추가

## 번들 크기 (before / after)

| 항목 | Before | After |
| --- | --- | --- |
| 648KB 하이라이터 청크 | 존재 (`refractor` 전 언어) | **제거됨** |
| `.next/static/chunks` 합계 | 1.4MB | **832KB** |
| 최대 청크 | 648KB (하이라이터) | 222KB (React 프레임워크) |

빌드 산출물(`.next/static/chunks`)에서 `react-syntax-highlighter`/`refractor` 마커가 포함된 청크가 **0개**임을 확인했다.

## 유지된 기능

- **다크 테마 하이라이팅**: darcula → github-dark (둘 다 다크, 색상 톤만 변경). 하이라이팅은 SSG HTML에 그대로 baked-in.
- **라인넘버**: shiki의 `[data-line]` 라인 span에 CSS `::before` 카운터로 구현. 이전 Prism이 모든 블록에 라인넘버를 붙이던 동작을 `defaultLang: 'text'`로 무언어 블록까지 보존.
- **복사 버튼**: 위치/아이콘/피드백 동작 유지. 복사 원문만 `pre.textContent`에서 읽도록 변경(라인넘버는 카운터라 textContent에 미포함).

## 검증

- `pnpm install` 성공
- `cd apps/blog && pnpm run build` 성공, 648KB 청크 제거 확인
- 빌드 HTML에 `data-rehype-pretty-code-figure` 36개, `data-line` 145개, 복사 버튼 12개, github-dark 토큰 색상 확인 (`ts-type-compatibility` 등)
- `pnpm run lint` 통과 (0 warnings)
- `pnpm run test` 통과 (17 suites / 63 tests)

## 트레이드오프 / 리스크

- 테마 색상이 darcula → github-dark로 변경됨(둘 다 다크 톤이라 시각적 위화감은 작음).
- 라인넘버 색상은 `rgba(255,255,255,0.35)`로 고정. 라이트/다크 토글이 없는 현재 구조에선 문제없음.
- SSR/하이드레이션: 서버·클라이언트 모두 MDX가 넘긴 동일 props로 `<pre>`를 렌더하므로 불일치 없음.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)