### PR TITLE
test(e2e): Playwright E2E 환경 도입 및 시나리오 5종 추가 (#30 2단계)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ node_modules
 # Testing
 coverage
 
+# Playwright E2E
+test-results/
+playwright-report/
+playwright/.cache/
+
 # Turbo
 .turbo
 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,31 @@
   - 혹시라도 Next.js API가 변경되더라도 서버 컴포넌트에서 가공하는 코드만 변경하면 해결되도록 하기 위해서 위와 같이 작업중입니다.
 - 조회한 데이터를 위의 타입으로 변환하는 Mapper 객체가 있습니다.
   - apps/blog/src/libs/mapper.ts에 있습니다.
+
+## 테스트
+
+블로그 앱(`apps/blog`)은 단위 테스트(Jest)와 E2E 테스트(Playwright)를 갖추고 있습니다.
+
+### 단위 테스트 (Jest)
+
+- `next/jest`(SWC 변환) 기반이며, `src` 하위의 `*.test.ts`를 실행합니다.
+- 주요 대상은 `src/libs`의 순수 로직(frontmatter, mapper, find-posts 등)입니다.
+
+```bash
+pnpm --filter blog test           # 1회 실행
+pnpm --filter blog test:watch     # 변경 감지 실행
+pnpm --filter blog test:coverage  # 커버리지 포함
+```
+
+### E2E 테스트 (Playwright)
+
+- `e2e` 디렉토리의 시나리오를 Chromium에서 실행합니다.
+- `playwright.config.ts`의 `webServer` 설정이 개발 서버(`pnpm dev`)를 자동으로 띄우므로, 별도 서버 실행 없이 바로 돌릴 수 있습니다.
+- 최초 1회 브라우저 설치가 필요합니다: `pnpm --filter blog exec playwright install chromium`
+
+```bash
+pnpm --filter blog test:e2e       # 헤드리스 실행
+pnpm --filter blog test:e2e:ui    # UI 모드(디버깅)
+```
+
+- 실패한 테스트는 스크린샷과 trace를 `apps/blog/test-results`에 남깁니다(git에는 포함되지 않습니다).

--- a/apps/blog/e2e/home.spec.ts
+++ b/apps/blog/e2e/home.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('메인 페이지', () => {
+  test('헤더(로고/네비)와 푸터가 렌더된다', async ({ page }) => {
+    // 랜딩 페이지로 진입한다.
+    await page.goto('/');
+
+    // 다크 헤더와 로고가 보여야 한다(헤더 안에는 메인 로고 + 모바일 사이드바 로고가 있어 first로 한정).
+    const header = page.locator('header.blog-main-header');
+    await expect(header).toBeVisible();
+    await expect(header.getByRole('link', { name: 'Malloc72p.Tech' }).first()).toBeVisible();
+
+    // 데스크톱 네비의 Tags 링크가 노출된다.
+    await expect(page.getByRole('link', { name: 'Tags' })).toBeVisible();
+
+    // 하단 푸터가 렌더된다.
+    await expect(page.locator('footer.blog-main-footer')).toBeVisible();
+  });
+});

--- a/apps/blog/e2e/not-found.spec.ts
+++ b/apps/blog/e2e/not-found.spec.ts
@@ -5,10 +5,11 @@ test.describe('존재하지 않는 경로', () => {
     // 존재할 수 없는 경로로 진입한다.
     const response = await page.goto('/this-route-does-not-exist-xyz');
 
-    // HTTP 응답 상태가 404여야 한다.
+    // HTTP 응답 상태가 404여야 한다(가장 안정적인 계약).
     expect(response?.status()).toBe(404);
 
-    // Next.js 기본 404 화면의 안내 문구가 보여야 한다(커스텀 404는 별도 이슈 #93).
-    await expect(page.getByText('This page could not be found')).toBeVisible();
+    // 화면에 404가 노출되는지 확인한다. Next 내부 문구 전체에 의존하지 않도록 "404"만 검증한다.
+    // (커스텀 404는 별도 이슈 #93)
+    await expect(page.locator('body')).toContainText('404');
   });
 });

--- a/apps/blog/e2e/not-found.spec.ts
+++ b/apps/blog/e2e/not-found.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('존재하지 않는 경로', () => {
+  test('없는 URL은 404 상태와 404 화면을 반환한다', async ({ page }) => {
+    // 존재할 수 없는 경로로 진입한다.
+    const response = await page.goto('/this-route-does-not-exist-xyz');
+
+    // HTTP 응답 상태가 404여야 한다.
+    expect(response?.status()).toBe(404);
+
+    // Next.js 기본 404 화면의 안내 문구가 보여야 한다(커스텀 404는 별도 이슈 #93).
+    await expect(page.getByText('This page could not be found')).toBeVisible();
+  });
+});

--- a/apps/blog/e2e/post.spec.ts
+++ b/apps/blog/e2e/post.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('포스트 목록 → 상세', () => {
+  test('첫 포스트 카드를 클릭하면 상세로 이동하고 제목(h1)과 작성일이 보인다', async ({ page }) => {
+    // 랜딩 페이지로 진입한다.
+    await page.goto('/');
+
+    // 시리즈 필터 배지도 href가 /posts/{series}(2-세그먼트)이고 클릭 시 네비를 막으므로,
+    // 실제 포스트 상세 링크(/posts/{series}/{postId}, 3-세그먼트)만 골라낸다.
+    const postLinks = page.locator('.blog-landing-page a[href^="/posts/"]');
+    const linkCount = await postLinks.count();
+    let firstPostLink: ReturnType<typeof postLinks.nth> | null = null;
+    for (let i = 0; i < linkCount; i++) {
+      const href = await postLinks.nth(i).getAttribute('href');
+      if (href && /^\/posts\/[^/]+\/[^/]+/.test(href)) {
+        firstPostLink = postLinks.nth(i);
+        break;
+      }
+    }
+    // 포스트 상세 링크가 반드시 존재해야 한다(없으면 타입을 좁히며 실패 처리).
+    expect(firstPostLink, '랜딩 목록에 포스트 상세 링크가 있어야 한다').not.toBeNull();
+    if (!firstPostLink) return;
+
+    await expect(firstPostLink).toBeVisible();
+
+    // 상세에서 동일성을 검증하기 위해 제목 텍스트를 먼저 확보한다.
+    const title = (await firstPostLink.innerText()).trim();
+    expect(title.length).toBeGreaterThan(0);
+
+    // 카드를 클릭해 상세로 이동한다.
+    await firstPostLink.click();
+
+    // 상세 경로(/posts/{series}/{postId})로 진입했는지 확인한다.
+    await expect(page).toHaveURL(/\/posts\/[^/]+\/[^/]+/);
+
+    // 상세 헤더의 h1에 목록에서 본 제목이 포함되어야 한다.
+    await expect(page.locator('h1')).toContainText(title);
+
+    // 상세 헤더(post-detail-header)에 작성일(연도 4자리)이 노출되어야 한다.
+    await expect(page.locator('header.post-detail-header')).toContainText(/\d{4}/);
+  });
+});

--- a/apps/blog/e2e/post.spec.ts
+++ b/apps/blog/e2e/post.spec.ts
@@ -33,8 +33,9 @@ test.describe('포스트 목록 → 상세', () => {
     // 상세 경로(/posts/{series}/{postId})로 진입했는지 확인한다.
     await expect(page).toHaveURL(/\/posts\/[^/]+\/[^/]+/);
 
-    // 상세 헤더의 h1에 목록에서 본 제목이 포함되어야 한다.
-    await expect(page.locator('h1')).toContainText(title);
+    // 상세 헤더의 제목 h1에 목록에서 본 제목이 포함되어야 한다.
+    // (본문 MDX가 별도 H1을 가질 수 있으므로 제목 헤더로 스코프를 한정한다 — 이슈 #98 참고)
+    await expect(page.locator('header.post-detail-header h1')).toContainText(title);
 
     // 상세 헤더(post-detail-header)에 작성일(연도 4자리)이 노출되어야 한다.
     await expect(page.locator('header.post-detail-header')).toContainText(/\d{4}/);

--- a/apps/blog/e2e/responsive.spec.ts
+++ b/apps/blog/e2e/responsive.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('모바일 반응형', () => {
+  // 모바일 폭(iPhone 12 수준)으로 뷰포트를 고정한다.
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('모바일에서 데스크톱 네비는 숨고, 햄버거로 사이드바를 열 수 있다', async ({ page }) => {
+    // 랜딩 페이지로 진입한다.
+    await page.goto('/');
+
+    // 데스크톱 전용 Tags 네비 링크는 md 미만에서 숨겨져야 한다.
+    await expect(page.getByRole('link', { name: 'Tags' })).toBeHidden();
+
+    // 햄버거(메뉴) 아이콘을 눌러 사이드바를 연다.
+    await page.locator('.tabler-icon-menu-2').click();
+
+    // 닫혀 있을 땐 화면 밖(translate-x-full)에 있던 사이드바의 Series 섹션 단락이
+    // 열린 뒤에는 뷰포트 안으로 들어와야 한다(패널이 실제로 슬라이드인됐음을 검증).
+    const sidebarSeries = page.getByRole('paragraph').filter({ hasText: /^Series$/ });
+    await expect(sidebarSeries).toBeInViewport();
+  });
+});

--- a/apps/blog/e2e/search.spec.ts
+++ b/apps/blog/e2e/search.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('검색', () => {
+  test('헤더 검색으로 글을 찾아 상세로 이동한다', async ({ page }) => {
+    await page.goto('/');
+
+    // 검색 인덱스는 모달을 열 때(open) 처음 fetch되므로, 클릭 전에 응답 대기를 걸어둔다.
+    // (인덱스 로드 전에 입력하면 결과가 갱신되지 않으므로 로드 완료를 보장해야 한다.)
+    const indexLoaded = page.waitForResponse((res) => res.url().includes('/search-index.json'));
+
+    // 헤더의 검색 버튼으로 모달을 연다.
+    await page.getByRole('button', { name: '포스트 검색 열기' }).click();
+
+    const dialog = page.getByRole('dialog', { name: '포스트 검색' });
+    await expect(dialog).toBeVisible();
+
+    // 인덱스 로드가 끝난 뒤 질의한다(다수 글 제목에 등장하는 'TypeScript').
+    await indexLoaded;
+    await dialog.getByRole('combobox').fill('TypeScript');
+
+    // 결과 목록(listbox)에 항목(option)이 하나 이상 나타난다.
+    const firstResult = dialog.getByRole('option').first();
+    await expect(firstResult).toBeVisible();
+
+    // 첫 결과를 클릭하면 모달이 닫히고 해당 포스트 상세로 이동한다.
+    await firstResult.getByRole('link').click();
+    await expect(page).toHaveURL(/\/posts\/[^/]+\/[^/]+/);
+    await expect(dialog).toBeHidden();
+  });
+});

--- a/apps/blog/e2e/series-tags.spec.ts
+++ b/apps/blog/e2e/series-tags.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('시리즈 / 태그 탐색', () => {
+  test('시리즈 페이지에 해당 시리즈 포스트 목록이 보인다', async ({ page }) => {
+    // frontend 시리즈 랜딩으로 진입한다.
+    await page.goto('/posts/frontend');
+
+    // 공통 헤더가 렌더되어야 한다.
+    await expect(page.locator('header.blog-main-header')).toBeVisible();
+
+    // 해당 시리즈의 포스트 상세로 가는 링크가 하나 이상 노출된다.
+    await expect(page.locator('a[href^="/posts/frontend/"]').first()).toBeVisible();
+  });
+
+  test('태그 인덱스에서 태그를 클릭하면 태그 상세로 이동한다', async ({ page }) => {
+    // 전체 태그 인덱스로 진입한다.
+    await page.goto('/tags');
+
+    // 페이지 제목(h1)이 Tags여야 한다.
+    await expect(page.locator('h1')).toContainText('Tags');
+
+    // 첫 번째 태그 배지를 클릭한다(헤더/사이드바의 태그 링크와 섞이지 않도록 본문 article로 한정).
+    const firstTag = page.locator('article a[href^="/tags/"]').first();
+    await expect(firstTag).toBeVisible();
+    await firstTag.click();
+
+    // 태그 상세 경로(/tags/{tag})로 진입했는지 확인한다.
+    await expect(page).toHaveURL(/\/tags\/.+/);
+  });
+});

--- a/apps/blog/jest.config.mjs
+++ b/apps/blog/jest.config.mjs
@@ -8,6 +8,8 @@ const config = {
   coverageProvider: 'v8',
   // 컴포넌트 렌더 테스트를 위해 jsdom. fs 기반 파이프라인 테스트도 Node가 받쳐주므로 함께 동작한다.
   testEnvironment: 'jsdom',
+  // Playwright E2E(e2e/*.spec.ts)는 jest가 잡지 않도록 제외한다(전용 러너로 실행).
+  testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/e2e/'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   // tsconfig의 path alias를 테스트에서도 해석할 수 있게 매핑한다.
   moduleNameMapper: {

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -11,7 +11,9 @@
     "start": "next start",
     "test": "TZ=\"Atlantic/Reykjavik\" jest",
     "test:watch": "TZ=\"Atlantic/Reykjavik\" jest --watch",
-    "test:coverage": "TZ=\"Atlantic/Reykjavik\" jest --coverage"
+    "test:coverage": "TZ=\"Atlantic/Reykjavik\" jest --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@giscus/react": "^3.1.0",
@@ -32,6 +34,7 @@
   },
   "devDependencies": {
     "@next/mdx": "^16.2.1",
+    "@playwright/test": "^1.61.1",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@tailwindcss/postcss": "^4",

--- a/apps/blog/playwright.config.ts
+++ b/apps/blog/playwright.config.ts
@@ -32,11 +32,12 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  // 테스트 실행 전 블로그 개발 서버를 자동으로 띄운다.
+  // 테스트 실행 전 블로그 서버를 자동으로 띄운다.
   webServer: {
-    // 프로젝트의 dev 스크립트를 그대로 사용한다(날짜 결정성을 위한 TZ 주입 포함).
-    command: 'pnpm dev',
-    // dev 서버 기본 포트가 응답하면 준비 완료로 간주한다.
+    // CI에서는 프로덕션 빌드(SSG/force-static/빌드타임 shiki 등)를 실제로 검증하기 위해 build+start를,
+    // 로컬에서는 빠른 반복을 위해 dev 서버를 사용한다(둘 다 dev 스크립트의 TZ 주입을 따른다).
+    command: process.env.CI ? 'pnpm build && pnpm start' : 'pnpm dev',
+    // 서버 기본 포트가 응답하면 준비 완료로 간주한다.
     url: 'http://localhost:3000',
     // 이미 떠 있는 서버가 있으면 재사용해 로컬 반복 실행을 빠르게 한다. CI는 항상 새로 띄운다.
     reuseExistingServer: !process.env.CI,

--- a/apps/blog/playwright.config.ts
+++ b/apps/blog/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E 설정.
+ *
+ * - 단위 테스트(jest)는 src의 *.test.ts를 담당하고, E2E는 이 설정으로 e2e 디렉토리만 다룬다.
+ * - webServer로 개발 서버를 자동 기동하므로 별도 서버 실행 없이 `pnpm test:e2e`만으로 동작한다.
+ */
+export default defineConfig({
+  // E2E 스펙은 e2e 디렉토리에만 둔다(jest의 src/*.test.ts와 분리).
+  testDir: './e2e',
+  // dev 모드는 라우트별 최초 진입 시 온디맨드 컴파일이 일어나므로 테스트 타임아웃을 넉넉히 둔다.
+  timeout: 60_000,
+  // CI에서만 실패 1회 재시도로 일시적 플레이키를 흡수한다(로컬은 즉시 실패가 디버깅에 유리).
+  retries: process.env.CI ? 1 : 0,
+  // 실패 원인 추적용 리포터. 로컬에서 결과를 바로 열어볼 수 있게 한다.
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    // 모든 테스트가 동일 출처를 바라보도록 기준 URL을 둔다(상대경로 goto 가능).
+    baseURL: 'http://localhost:3000',
+    // dev 컴파일 지연을 감안해 내비게이션 타임아웃을 여유 있게 잡는다.
+    navigationTimeout: 45_000,
+    // 첫 재시도부터 trace를 남겨 실패 분석이 가능하게 한다.
+    trace: 'on-first-retry',
+    // 실패한 테스트에 한해 스크린샷을 저장한다.
+    screenshot: 'only-on-failure',
+  },
+  // 단일 브라우저(Chromium)로 시작한다. 필요해지면 프로젝트를 추가한다.
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // 테스트 실행 전 블로그 개발 서버를 자동으로 띄운다.
+  webServer: {
+    // 프로젝트의 dev 스크립트를 그대로 사용한다(날짜 결정성을 위한 TZ 주입 포함).
+    command: 'pnpm dev',
+    // dev 서버 기본 포트가 응답하면 준비 완료로 간주한다.
+    url: 'http://localhost:3000',
+    // 이미 떠 있는 서버가 있으면 재사용해 로컬 반복 실행을 빠르게 한다. CI는 항상 새로 띄운다.
+    reuseExistingServer: !process.env.CI,
+    // 최초 컴파일/기동 시간을 감안해 서버 대기 타임아웃을 넉넉히 둔다.
+    timeout: 180_000,
+  },
+});

--- a/apps/blog/src/components/badge.test.tsx
+++ b/apps/blog/src/components/badge.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Badge } from './badge';
+
+describe('Badge', () => {
+  it('href를 가진 링크로 렌더되고, onClick이 없으면 aria-current가 없다', () => {
+    render(<Badge href="/posts/frontend">FE</Badge>);
+
+    const link = screen.getByRole('link', { name: 'FE' });
+    // 배지는 항상 실제 링크(<a>)로 렌더되어 접근성/딥링크를 보장한다.
+    expect(link).toHaveAttribute('href', '/posts/frontend');
+    // 필터로 쓰이지 않을 땐 현재 항목 표시가 없어야 한다.
+    expect(link).not.toHaveAttribute('aria-current');
+  });
+
+  it('onClick이 있으면 클릭 시 기본 이동을 막고(preventDefault) 콜백을 호출한다', () => {
+    const onClick = jest.fn();
+    render(
+      <Badge href="/posts/frontend" onClick={onClick}>
+        FE
+      </Badge>,
+    );
+
+    const link = screen.getByRole('link', { name: 'FE' });
+    // fireEvent.click은 기본 동작이 취소(preventDefault)되면 false를 반환한다.
+    const notCancelled = fireEvent.click(link);
+
+    // 필터 클릭은 페이지 이동 대신 콜백만 실행되어야 한다(랜딩 시리즈 필터의 동작).
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(notCancelled).toBe(false);
+  });
+
+  it('active=true면 aria-current="true"를 부여한다', () => {
+    render(
+      <Badge href="/posts/frontend" active>
+        FE
+      </Badge>,
+    );
+
+    expect(screen.getByRole('link', { name: 'FE' })).toHaveAttribute('aria-current', 'true');
+  });
+});

--- a/apps/blog/src/components/post-detail/copy-button.test.tsx
+++ b/apps/blog/src/components/post-detail/copy-button.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CopyButton } from './copy-button';
+
+describe('CopyButton', () => {
+  // navigator.clipboard.writeText를 모킹해 클립보드 접근을 제어한다.
+  const writeText = jest.fn();
+
+  beforeEach(() => {
+    writeText.mockReset().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  it('초기에는 "코드 복사" 라벨의 버튼을 렌더한다', () => {
+    render(<CopyButton getContent={() => 'const a = 1;'} />);
+
+    expect(screen.getByRole('button', { name: '코드 복사' })).toBeInTheDocument();
+  });
+
+  it('클릭하면 getContent() 결과를 클립보드에 쓰고 "코드 복사됨"으로 피드백한다', async () => {
+    render(<CopyButton getContent={() => 'const a = 1;'} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '코드 복사' }));
+
+    // 클립보드에 코드가 그대로 전달되어야 한다.
+    expect(writeText).toHaveBeenCalledWith('const a = 1;');
+    // 복사 성공 후 라벨이 바뀌어 스크린리더에 결과를 알린다.
+    expect(await screen.findByRole('button', { name: '코드 복사됨' })).toBeInTheDocument();
+  });
+
+  it('클립보드 쓰기에 실패해도 예외를 던지지 않고 라벨이 유지된다', async () => {
+    writeText.mockRejectedValue(new Error('clipboard denied'));
+    render(<CopyButton getContent={() => 'const a = 1;'} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '코드 복사' }));
+
+    // 실패는 조용히 흡수되므로 라벨이 "코드 복사" 그대로여야 한다.
+    expect(await screen.findByRole('button', { name: '코드 복사' })).toBeInTheDocument();
+    expect(writeText).toHaveBeenCalled();
+  });
+});

--- a/apps/blog/src/components/post-json-ld.test.tsx
+++ b/apps/blog/src/components/post-json-ld.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+import { PostJsonLd } from './post-json-ld';
+import { PostModel, SeriesModel } from '@libs/types/commons';
+
+const series: SeriesModel = { id: 'frontend', title: 'Frontend', date: '2026-01-01' };
+const post: PostModel = {
+  id: 'my-post',
+  route: '/posts/frontend/my-post',
+  series,
+  title: '내 포스트 제목',
+  tags: [{ id: 'react' }, { id: 'nextjs' }],
+  date: '2026-01-02 10:00',
+};
+
+// 렌더된 <script type="application/ld+json">의 내용을 파싱해 반환한다.
+function renderJsonLd() {
+  const { container } = render(<PostJsonLd post={post} series={series} />);
+  const script = container.querySelector('script[type="application/ld+json"]');
+  expect(script).not.toBeNull();
+  return JSON.parse(script?.textContent ?? '{}');
+}
+
+describe('PostJsonLd', () => {
+  it('BlogPosting 스키마와 핵심 필드를 출력한다', () => {
+    const data = renderJsonLd();
+
+    expect(data['@context']).toBe('https://schema.org');
+    expect(data['@type']).toBe('BlogPosting');
+    expect(data.headline).toBe('내 포스트 제목');
+    expect(data.articleSection).toBe('Frontend');
+    expect(data.keywords).toEqual(['react', 'nextjs']);
+    expect(data.inLanguage).toBe('ko');
+  });
+
+  it('url은 사이트 URL + route를 이중 슬래시 없이 연결한다 (#84 회귀 방지)', () => {
+    const data = renderJsonLd();
+
+    expect(data.url).toBe('https://blog.malloc72p.com/posts/frontend/my-post');
+    // 프로토콜(https://)을 제외하면 연속 슬래시가 없어야 한다.
+    expect(data.url.replace('https://', '')).not.toContain('//');
+  });
+
+  it('datePublished/dateModified는 타임존 오프셋을 포함한 ISO 8601이다 (#84 회귀 방지)', () => {
+    const data = renderJsonLd();
+
+    // DateUtil이 Asia/Seoul을 강제하므로 머신 TZ와 무관하게 +09:00이 된다.
+    expect(data.datePublished).toBe('2026-01-02T10:00:00+09:00');
+    expect(data.dateModified).toBe(data.datePublished);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,10 +34,10 @@ importers:
         version: 3.31.0(react@19.2.4)
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(next@16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)
+        version: 1.5.0(next@16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)
       '@vercel/speed-insights':
         specifier: ^1.2.0
-        version: 1.2.0(next@16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)
+        version: 1.2.0(next@16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -49,7 +49,7 @@ importers:
         version: 7.4.2
       next:
         specifier: ^16.2.1
-        version: 16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
+        version: 16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -69,6 +69,9 @@ importers:
       '@next/mdx':
         specifier: ^16.2.1
         version: 16.2.1(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
@@ -910,6 +913,11 @@ packages:
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@shikijs/core@4.3.0':
     resolution: {integrity: sha512-EooU3i9F6IAE8kEu+AnGf9DFZWkQBZ+hJn3tLVbsH+61mtQiva5biai66fAA6nvFPXkLgvrh7BrR7YcJU83xQQ==}
@@ -1999,6 +2007,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3056,6 +3069,16 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
@@ -4510,6 +4533,10 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@shikijs/core@4.3.0':
     dependencies:
       '@shikijs/primitive': 4.3.0
@@ -4925,14 +4952,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vercel/analytics@1.5.0(next@16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)':
+  '@vercel/analytics@1.5.0(next@16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
+      next: 16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
       react: 19.2.4
 
-  '@vercel/speed-insights@1.2.0(next@16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)':
+  '@vercel/speed-insights@1.2.0(next@16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
+      next: 16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
       react: 19.2.4
 
   acorn-jsx@5.3.2(acorn@8.14.0):
@@ -5671,6 +5698,9 @@ snapshots:
       signal-exit: 4.1.0
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -7054,7 +7084,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.1(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1):
+  next@16.2.1(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1):
     dependencies:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
@@ -7073,6 +7103,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.1
       '@next/swc-win32-arm64-msvc': 16.2.1
       '@next/swc-win32-x64-msvc': 16.2.1
+      '@playwright/test': 1.61.1
       sass: 1.85.1
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -7222,6 +7253,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.0.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "globalEnv": ["CI"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -19,6 +20,13 @@
     "dev": {
       "cache": false,
       "persistent": true
+    },
+    "test": {
+      "dependsOn": ["^build"]
+    },
+    "test:e2e": {
+      "dependsOn": ["^build"],
+      "cache": false
     },
     "seed": {
       "dependsOn": ["^seed"],


### PR DESCRIPTION
## 개요

이슈 #30의 **2단계(Playwright E2E)** 를 구현합니다. 1단계(Jest 단위 테스트)는 #80에서 완료되었고, 이 PR은 남은 E2E 환경 + turbo 태스크 + 문서화를 다룹니다.

## 변경 사항

- **playwright.config.ts**: `webServer`로 dev 서버 자동 기동, `baseURL`, 실패 시 스크린샷/trace 저장, Chromium 단일 프로젝트
- **e2e/**: 시나리오 5개
  - `home` — 헤더(로고/네비)·푸터 렌더
  - `post` — 목록 → 상세 진입, 제목(h1)·작성일 노출
  - `series-tags` — 시리즈 페이지 / 태그 인덱스 → 태그 상세 탐색
  - `not-found` — 존재하지 않는 경로 404
  - `responsive` — 모바일 뷰포트에서 데스크톱 네비 숨김 + 햄버거 사이드바 오픈
- **package.json**: `test:e2e`, `test:e2e:ui` 스크립트 + `@playwright/test`
- **jest.config.mjs**: `e2e/`를 jest 대상에서 제외(전용 러너로 실행)
- **turbo.json**: `test`, `test:e2e` 태스크 + `globalEnv: ["CI"]`
- **.gitignore**: Playwright 산출물(`test-results/`, `playwright-report/`, `playwright/.cache/`) 무시
- **README.md**: 단위/E2E 테스트 실행 방법 문서화

## 검증

- `pnpm --filter blog test` → 단위 63개 통과
- `pnpm --filter blog test:e2e` → E2E 6개 통과
- `pnpm lint` 경고 0, `tsc --noEmit` 오류 없음

## 범위에서 제외 (이슈상 선택 항목)

- CI(GitHub Actions) 워크플로우 — 별도 후속으로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)