### PR TITLE
fix(blog): #118 본문 풀폭·인라인 코드 회색 배경·모바일 줄간격 복원

### DIFF
--- a/apps/blog/next.config.mjs
+++ b/apps/blog/next.config.mjs
@@ -18,7 +18,9 @@ const withMDX = createMDX({
           keepBackground: true,
           // 언어를 명시하지 않은 코드블록도 동일하게 grid/라인 처리되도록 기본 언어를 지정한다.
           // (이전 Prism 구현은 모든 블록에 라인넘버를 붙였으므로 그 동작을 보존한다.)
-          defaultLang: 'text',
+          // block 키로 한정한다: 문자열로 주면 인라인 코드(백틱 1개)에도 적용돼
+          // shiki가 다크 배경을 inline style로 주입(keepBackground) → 회색 배경이 덮인다.
+          defaultLang: { block: 'text' },
         },
       ],
     ],

--- a/apps/blog/src/components/post-detail/post-detail.module.scss
+++ b/apps/blog/src/components/post-detail/post-detail.module.scss
@@ -23,9 +23,6 @@
     padding-bottom: 24px;
     line-height: 28px;
     word-break: keep-all;
-    // 데스크톱에서 한 줄이 지나치게 길어지지 않도록 가독 권장 폭(약 70자)으로 제한한다.
-    // 코드블록/이미지/표는 아래에서 풀폭을 유지하므로 영향받지 않는다.
-    max-width: 70ch;
   }
 
   ul,
@@ -137,10 +134,11 @@
     p {
       padding-top: 8px;
       padding-bottom: 12px;
-      line-height: 22px;
+      // 본문 14px 기준 가독 line-height. 폰트가 12→14px로 커졌는데 22px에 머물러
+      // 줄간격 비율이 좁아졌던 것을 데스크톱(28px/16px≈1.75)과 같은 비율로 복원한다.
+      line-height: 25px;
       font-size: 14px; // 모바일 가독성을 위해 12px에서 14px로 상향
       word-break: keep-all;
-      max-width: none; // 모바일은 화면이 좁아 측정폭 제한이 불필요하므로 해제
     }
 
     ul,

--- a/apps/blog/src/components/post-detail/post-detail.module.scss
+++ b/apps/blog/src/components/post-detail/post-detail.module.scss
@@ -135,7 +135,7 @@
       padding-top: 8px;
       padding-bottom: 12px;
       // 본문 14px 기준 가독 line-height. 폰트가 12→14px로 커졌는데 22px에 머물러
-      // 줄간격 비율이 좁아졌던 것을 데스크톱(28px/16px≈1.75)과 같은 비율로 복원한다.
+      // 줄간격 비율이 1.57로 좁아졌던 것을, 데스크톱 비율(28px/16px≈1.75)에 근접하게 복원한다(25/14≈1.79).
       line-height: 25px;
       font-size: 14px; // 모바일 가독성을 위해 12px에서 14px로 상향
       word-break: keep-all;


### PR DESCRIPTION
## 개요

Closes #118

최근 스타일 수정에서 발생한 3가지 회귀를 **원인 커밋 기준**으로 바로잡습니다. 모두 빌드 + 렌더된 HTML/CSS로 검증했습니다.

| # | 증상 | 원인 커밋 | 수정 |
|---|------|----------|------|
| 1 | 본문 텍스트가 좌측에 쏠려(풀폭 X) 보임 | #70 `0b0d8d1` — `p { max-width: 70ch }` | `70ch` 제거 (+ 짝인 모바일 `max-width:none` 정리) |
| 2 | 인라인 코드(백틱 1개) 배경이 너무 진함 | #96 `ebf8e35` — `defaultLang: 'text'`(문자열) | `defaultLang: { block: 'text' }` |
| 3 | 모바일 본문 줄간격이 좁아진 느낌 | #70 `0b0d8d1` — 14px인데 `line-height: 22px` | `line-height: 25px`로 비율 복원 |

## 원인 분석

### 1. 본문 풀폭
`#70`에서 데스크톱 가독성을 위해 단락에 `max-width: 70ch`를 넣었는데, 본문 칼럼(`max-w-[1024px]`)보다 훨씬 좁아 텍스트가 왼쪽에 몰리고 우측이 비어 "가운데 정렬이 안 된 것처럼" 보였습니다. 특별한 이유가 없으면 풀폭을 쓰자는 요구에 따라 제거했습니다.

### 2. 인라인 코드 다크 배경 (핵심)
`rehype-pretty-code@0.14.3` 소스(`dist/index.js`)에서 확인:
```js
const defaultInlineCodeLang = typeof defaultLang === "string" ? defaultLang : defaultLang.inline || "";
```
`defaultLang`을 **문자열** `'text'`로 주면 인라인 코드의 기본 언어로도 적용됩니다. 그러면 plain 인라인 코드(`` `setTimeout` ``)도 shiki가 `github-dark`로 하이라이팅하고, `keepBackground: true`가 다크 배경을 **inline style**로 주입해 CSS의 `--color-gray-100`(연회색)을 덮어썼습니다.

`{ block: 'text' }`로 한정하면 코드블록 라인넘버 동작은 그대로 유지되고, 인라인 코드는 다시 plain `<code>`로 남아 회색 배경을 회복합니다.

### 3. 모바일 줄간격
`#70`에서 모바일 폰트를 12→14px로 키웠지만 `line-height`는 20→22px에 그쳐, 줄간격 비율이 1.67→1.57로 **오히려 좁아졌습니다**(데스크톱은 28px/16px≈1.75로 정상). 같은 비율이 되도록 25px(≈1.79)로 복원했습니다.

## 검증

- `pnpm run build` 성공, `lint`·`tsc --noEmit` 통과
- 렌더된 HTML(`event-loop`):
  - 인라인 코드 → `<code>setTimeout</code>` (inline style/figure 래핑 없음) → CSS `--color-gray-100: #f3f4f6` 적용
  - 코드블록 → `<pre style="background-color:#24292e">` 다크 유지
- 빌드 CSS에서 `70ch` 완전히 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)