### PR TITLE
feat(blog): 최신글 통합 피드에서 특정 시리즈 제외 설정 메커니즘 (#25)

### DIFF
--- a/apps/blog/src/app/(main)/page.tsx
+++ b/apps/blog/src/app/(main)/page.tsx
@@ -20,6 +20,11 @@ export default async function LandingPage() {
       continue;
     }
 
+    // 랜딩 페이지(최신글 통합 피드)에서 제외할 시리즈. 시리즈 자체 페이지(/posts/{id})는 영향받지 않는다.
+    if (Constants.series.excludedFromLatestIds.includes(series.id)) {
+      continue;
+    }
+
     const seriesPost = await findPosts({
       seriesId: series.id,
     });

--- a/apps/blog/src/libs/api/find-posts.test.ts
+++ b/apps/blog/src/libs/api/find-posts.test.ts
@@ -1,5 +1,6 @@
 import { findPosts } from '@libs/api/find-posts';
 import { getAllMdxFiles, MdxFileInfo } from '@libs/api/mdx-utils';
+import { Constants } from '@libs/constants';
 
 // fs를 읽는 getAllMdxFiles를 mock해 실제 글과 무관하게 "필터/정렬/limit" 로직만 검증한다.
 jest.mock('@libs/api/mdx-utils');
@@ -57,6 +58,44 @@ describe('findPosts', () => {
 
     const posts = await findPosts({ limit: 2 });
     expect(posts).toHaveLength(2);
+  });
+
+  describe('excludedFromLatestIds (#25)', () => {
+    const original = Constants.series.excludedFromLatestIds;
+    afterEach(() => {
+      Constants.series.excludedFromLatestIds = original;
+    });
+
+    it("seriesId가 'latest'면 제외 목록의 시리즈 글을 뺀다", async () => {
+      Constants.series.excludedFromLatestIds = ['fullstack'];
+      mockGetAll.mockResolvedValue([
+        f('frontend/a', { series: 'frontend', date: '2026-01-01 00:00' }),
+        f('fullstack/x', { series: 'fullstack', date: '2026-02-01 00:00' }),
+      ]);
+
+      const posts = await findPosts({ seriesId: 'latest' });
+      expect(posts.map((p) => p.slug)).toEqual(['frontend/a']);
+    });
+
+    it('제외 목록에 있어도 해당 시리즈를 직접 조회하면 그대로 반환한다', async () => {
+      Constants.series.excludedFromLatestIds = ['fullstack'];
+      mockGetAll.mockResolvedValue([
+        f('fullstack/x', { series: 'fullstack', date: '2026-02-01 00:00' }),
+      ]);
+
+      const posts = await findPosts({ seriesId: 'fullstack' });
+      expect(posts.map((p) => p.slug)).toEqual(['fullstack/x']);
+    });
+
+    it('seriesId 없이 호출하면(전체 글 목록) 제외 목록의 영향을 받지 않는다', async () => {
+      Constants.series.excludedFromLatestIds = ['fullstack'];
+      mockGetAll.mockResolvedValue([
+        f('fullstack/x', { series: 'fullstack', date: '2026-02-01 00:00' }),
+      ]);
+
+      const posts = await findPosts();
+      expect(posts.map((p) => p.slug)).toEqual(['fullstack/x']);
+    });
   });
 
   it("orderBy 'createAtASC'는 오래된 순으로 정렬한다", async () => {

--- a/apps/blog/src/libs/api/find-posts.ts
+++ b/apps/blog/src/libs/api/find-posts.ts
@@ -21,7 +21,13 @@ export async function findPosts(
   posts = posts.filter((post) => !post.frontMatter.isSeriesLanding);
 
   // 시리즈 필터링
-  if (seriesId && seriesId !== Constants.series.latestId) {
+  if (seriesId === Constants.series.latestId) {
+    // '최신글' 통합 피드(/posts/latest)에서는 설정된 시리즈를 제외한다.
+    // seriesId가 없는 호출(전체 글 목록·태그·사이트맵 등)은 영향받지 않는다.
+    posts = posts.filter(
+      (post) => !Constants.series.excludedFromLatestIds.includes(post.frontMatter.series ?? ''),
+    );
+  } else if (seriesId) {
     posts = posts.filter((post) => post.frontMatter.series === seriesId);
   }
 

--- a/apps/blog/src/libs/constants.ts
+++ b/apps/blog/src/libs/constants.ts
@@ -1,6 +1,9 @@
 export const Constants = {
   series: {
     latestId: 'latest',
+    // '최신글' 통합 피드(랜딩 페이지 기본 보기 + /posts/latest)에서 제외할 시리즈 ID.
+    // 개별 시리즈 페이지(/posts/{id})와 태그·사이트맵 등 전체 글 목록에는 영향을 주지 않는다.
+    excludedFromLatestIds: [] as string[],
   },
   a11y: {
     // skip 링크(본문 바로가기)와 <main> 타깃을 잇는 앵커 id. 두 파일이 같은 값을 공유하도록 단일화한다.


### PR DESCRIPTION
#25 검토 결과 "제외할 시리즈"가 구체적으로 정해지지 않아, **설정 메커니즘만** 구현합니다(사용자 확인 완료). 지금은 빈 배열이라 **동작 변화 없음** — 나중에 시리즈 ID만 추가하면 바로 동작합니다.

## 구현
- `Constants.series.excludedFromLatestIds: string[]`(빈 배열) 추가
- `findPosts`가 `seriesId === 'latest'`(즉 `/posts/latest` 페이지)일 때만 제외 목록을 존중
- 랜딩 페이지의 시리즈별 루프에도 동일 제외 적용(랜딩의 "최신글" 통합 뷰)

## 범위 밖(의도적으로 미적용)
- **개별 시리즈 페이지**(`/posts/{id}`): 제외 목록에 있어도 그 시리즈 자체 페이지는 그대로 보임
- **태그 페이지·사이트맵·`seriesId` 없는 전체 글 목록**(레이아웃의 prev/next 계산 포함): 영향 없음

`seriesId`가 없는 호출까지 필터링하면 사이트맵 누락·prev/next 네비게이션 깨짐 등 부작용이 생기므로, "최신글 통합 피드"에만 범위를 좁혔습니다.

## 검증
- `find-posts.test`: 최신글 제외 / 개별 시리즈 미영향 / 전체 목록 미영향 3케이스 추가
- 단위 84개 / E2E 8개(프로덕션 빌드, 동작 변화 없음 확인) / lint 0 / tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)