### PR TITLE
fix(blog): 포스트 타입 스케일 토큰화·모바일 헤딩 위계 복원·Noto Sans KR 활성화 (#95)

### DIFF
--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -5,17 +5,18 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Constants } from '@libs/constants';
 
-// Noto Sans KR을 서브셋으로 최적화
-// - 한글 기본 2,350자만 포함 (전체 11,172자 대신)
-// - 폰트 크기: 76KB → ~20KB로 감소
-// - swap: 폰트 로딩 중에도 텍스트 표시
 // OS별 한글 렌더링 편차를 없애기 위해 활성화(#95). next/font는 빌드타임에 셀프호스트하므로
 // 런타임에 fonts.googleapis.com으로 나가는 요청(preconnect 포함)이 필요 없다.
+// subsets는 프리로드 대상(latin woff2)만 지정한다 — next/font의 Noto_Sans_KR에는 'korean'
+// 서브셋이 없어, 한글 글리프는 unicode-range 슬라이스(다수의 woff2)로 필요한 만큼 온디맨드
+// 로드된다. 따라서 첫 방문 시 한글은 폴백→스왑(FOUT)이 발생하며, 아래 display/adjustFontFallback
+// 조합으로 로딩 중 표시와 스왑 시 CLS를 완화한다.
 const font = Noto_Sans_KR({
-  weight: ['400', '700'], // 필요한 weight만 로드
+  // 실사용 weight만 로드: 400(본문)·500(font-medium 강조)·700(헤딩/볼드).
+  // 600은 th(post-detail.module.scss) 한 곳뿐이라 로드하지 않고 700 상향 매칭을 감수한다.
+  weight: ['400', '500', '700'],
   subsets: ['latin'],
   display: 'swap', // 폰트 로딩 중에도 텍스트 즉시 표시
-  variable: '--font-noto-sans-kr',
   preload: true,
   fallback: ['system-ui', '-apple-system', 'sans-serif'],
   adjustFontFallback: true, // CLS 방지

--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 import './global.css';
-// import { Noto_Sans_KR } from 'next/font/google';
+import { Noto_Sans_KR } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Constants } from '@libs/constants';
@@ -9,15 +9,17 @@ import { Constants } from '@libs/constants';
 // - 한글 기본 2,350자만 포함 (전체 11,172자 대신)
 // - 폰트 크기: 76KB → ~20KB로 감소
 // - swap: 폰트 로딩 중에도 텍스트 표시
-// const font = Noto_Sans_KR({
-//   weight: ['400', '700'], // 필요한 weight만 로드
-//   subsets: ['latin'],
-//   display: 'swap', // 폰트 로딩 중에도 텍스트 즉시 표시
-//   variable: '--font-noto-sans-kr',
-//   preload: true,
-//   fallback: ['system-ui', '-apple-system', 'sans-serif'],
-//   adjustFontFallback: true, // CLS 방지
-// });
+// OS별 한글 렌더링 편차를 없애기 위해 활성화(#95). next/font는 빌드타임에 셀프호스트하므로
+// 런타임에 fonts.googleapis.com으로 나가는 요청(preconnect 포함)이 필요 없다.
+const font = Noto_Sans_KR({
+  weight: ['400', '700'], // 필요한 weight만 로드
+  subsets: ['latin'],
+  display: 'swap', // 폰트 로딩 중에도 텍스트 즉시 표시
+  variable: '--font-noto-sans-kr',
+  preload: true,
+  fallback: ['system-ui', '-apple-system', 'sans-serif'],
+  adjustFontFallback: true, // CLS 방지
+});
 
 const { siteConfig, openGraph } = Constants;
 
@@ -86,15 +88,14 @@ export default async function RootLayout({ children }: PropsWithChildren) {
           }}
         />
         <link rel="icon" type="image/x-icon" href="/favicon.ico"></link>
-        {/* <link rel="preconnect" href="https://fonts.googleapis.com" /> */}
-        {/* <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" /> */}
         <meta
           name="google-site-verification"
           content="mOdpcnnT3rL3phLYQpSNvzcOOGfKppuH-2mgeOs7VIc"
         />
       </head>
 
-      <body>
+      {/* font.className이 셀프호스트된 Noto Sans KR과 조정된 폴백(fallback)을 body 전체에 적용한다. */}
+      <body className={font.className}>
         {children}
 
         <SpeedInsights />

--- a/apps/blog/src/components/post-detail/post-detail.module.scss
+++ b/apps/blog/src/components/post-detail/post-detail.module.scss
@@ -40,6 +40,8 @@
   ul,
   ol {
     padding: 5px 0;
+    // 본문 크기의 단일 출처를 위해 리스트도 토큰을 참조한다(기본값 16px과 동일해 시각 변화 없음).
+    font-size: var(--post-body-size);
   }
 
   li {
@@ -109,6 +111,8 @@
     width: 100%;
     margin: 16px 0;
     border-collapse: collapse;
+    // 표 본문도 본문 크기 토큰을 따른다(기본값 16px과 동일해 시각 변화 없음).
+    font-size: var(--post-body-size);
   }
 
   th,
@@ -148,7 +152,7 @@
     ul,
     ol {
       padding: 0;
-      font-size: var(--post-body-size); // 본문 폰트와 통일 (12px→14px 상향 이력, #95에서 토큰화)
+      // font-size는 기본 스코프의 토큰 선언이 모바일 토큰 값(14px)으로 재해석되므로 중복 선언하지 않는다.
     }
 
     li {
@@ -195,10 +199,7 @@
       }
     }
 
-    table {
-      font-size: var(--post-body-size); // 본문 폰트와 통일 (12px→14px 상향 이력, #95에서 토큰화)
-    }
-
+    // table의 font-size는 기본 스코프의 토큰 선언이 모바일 토큰 값(14px)으로 재해석되므로 중복 선언하지 않는다.
     th,
     td {
       padding: 6px 8px;

--- a/apps/blog/src/components/post-detail/post-detail.module.scss
+++ b/apps/blog/src/components/post-detail/post-detail.module.scss
@@ -1,4 +1,12 @@
 .postDetail {
+  // === 타입 스케일 토큰 (#95) ===
+  // 흩어진 px 하드코딩을 토큰으로 모아 h1 > h2 > h3 > 본문 위계가 항상 유지되게 한다.
+  // 모바일 값은 하단 미디어쿼리에서 같은 토큰만 덮어쓴다.
+  --post-h1-size: 32px;
+  --post-h2-size: 24px;
+  --post-h3-size: 20px; // 본문(16px)과 같아 위계가 없던 16px에서 한 단계 상향
+  --post-body-size: 16px;
+
   h1,
   h2,
   h3 {
@@ -7,21 +15,25 @@
   }
 
   h1 {
-    font-size: 32px;
+    font-size: var(--post-h1-size);
   }
 
   h2 {
-    font-size: 24px;
+    font-size: var(--post-h2-size);
   }
 
   h3 {
-    font-size: 16px;
+    font-size: var(--post-h3-size);
   }
 
   p {
     padding-top: 16px;
     padding-bottom: 24px;
-    line-height: 28px;
+    // 한글 본문 가독성을 위해 28px(비율 1.75)에서 1.8로 상향(#95).
+    // unitless 비율이라 모바일 본문 14px에서도 같은 비율(약 25.2px)로 스케일되어
+    // #118에서 복원한 모바일 줄간격(25px, 약 1.79)의 의도를 그대로 계승한다.
+    line-height: 1.8;
+    font-size: var(--post-body-size);
     word-break: keep-all;
   }
 
@@ -112,6 +124,13 @@
   }
 
   @media only screen and (max-width: 800px) {
+    // 모바일 타입 스케일(#95): 기존 h2 16px·h3 14px가 본문 14px과 겹쳐 위계가 사라졌던 것을,
+    // 본문 14px 기준으로 h3까지 최소 한 단계(2px 이상) 차이가 유지되도록 토큰만 덮어쓴다.
+    --post-h1-size: 24px;
+    --post-h2-size: 20px;
+    --post-h3-size: 16px;
+    --post-body-size: 14px;
+
     h1,
     h2,
     h3 {
@@ -119,32 +138,17 @@
       padding: 10px 0;
     }
 
-    h1 {
-      font-size: 24px;
-    }
-
-    h2 {
-      font-size: 16px;
-    }
-
-    h3 {
-      font-size: 14px;
-    }
-
     p {
       padding-top: 8px;
       padding-bottom: 12px;
-      // 본문 14px 기준 가독 line-height. 폰트가 12→14px로 커졌는데 22px에 머물러
-      // 줄간격 비율이 1.57로 좁아졌던 것을, 데스크톱 비율(28px/16px≈1.75)에 근접하게 복원한다(25/14≈1.79).
-      line-height: 25px;
-      font-size: 14px; // 모바일 가독성을 위해 12px에서 14px로 상향
-      word-break: keep-all;
+      // 폰트 크기는 --post-body-size(14px) 토큰이, 줄간격은 상단의 unitless 1.8이 담당한다.
+      // (#118에서 복원한 25px≈1.79 비율은 1.8 비율 상속으로 그대로 유지된다)
     }
 
     ul,
     ol {
       padding: 0;
-      font-size: 14px; // 본문 폰트와 통일해 12px에서 14px로 상향
+      font-size: var(--post-body-size); // 본문 폰트와 통일 (12px→14px 상향 이력, #95에서 토큰화)
     }
 
     li {
@@ -192,7 +196,7 @@
     }
 
     table {
-      font-size: 14px; // 본문 폰트와 통일해 12px에서 14px로 상향
+      font-size: var(--post-body-size); // 본문 폰트와 통일 (12px→14px 상향 이력, #95에서 토큰화)
     }
 
     th,

--- a/apps/blog/tailwind.config.js
+++ b/apps/blog/tailwind.config.js
@@ -10,7 +10,6 @@ export default {
     extend: {
       fontFamily: {
         sans: ['system-ui', 'sans-serif'],
-        // sans: ['var(--font-noto-sans-kr)', 'system-ui', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## 배경

모바일(≤800px)에서 포스트 헤딩이 h1 24px / h2 16px / h3 14px로 줄어들어 본문 14px과 겹치면서 헤딩 위계가 사라졌다. 데스크톱에서도 h3(16px)가 본문(16px)과 같았다. 또한 폰트가 system-ui뿐이라 OS별 한글 렌더링 편차가 있었고, Noto Sans KR 설정은 layout.tsx에 주석으로만 남아 있었다.

## 구현

- **타입 스케일 토큰화** (`post-detail.module.scss`)
  - 헤딩/본문 크기를 `--post-h1-size`/`--post-h2-size`/`--post-h3-size`/`--post-body-size` 토큰으로 모으고, 모바일 미디어쿼리에서는 토큰 값만 덮어쓴다.
  - 데스크톱: h1 32 / h2 24 / h3 20 / 본문 16px (h3를 16→20px로 상향해 본문과의 위계 확보)
  - 모바일: h1 24 / h2 20 / h3 16 / 본문 14px (h3까지 본문과 최소 한 단계 차이 유지)
  - 모바일 ul/ol/table의 "본문 폰트와 통일" 크기도 같은 토큰을 참조하도록 변경.
- **한글 본문 줄간격 상향**
  - `line-height: 28px`(1.75) → unitless `1.8`. 비율이라 모바일 14px에서도 약 25.2px로 스케일되어 #118에서 복원한 25px(≈1.79)의 의도를 그대로 계승한다.
- **Noto Sans KR 활성화** (`layout.tsx`)
  - 주석 처리돼 있던 `Noto_Sans_KR(next/font/google)` 설정을 활성화하고 `font.className`을 body에 적용.
  - next/font는 빌드타임 셀프호스트이므로 불필요해진 fonts.googleapis.com preconnect 주석을 제거.

## 범위 밖

- 코드블록(`pre`)의 모바일 14px은 코드 가독성이라는 독립 사유가 있어 리터럴 유지.
- `li`의 line-height(28px) 등 이슈에서 지적되지 않은 기존 수치는 변경하지 않음.
- Pretendard 등 다른 폰트 도입은 하지 않음 — 기존에 준비돼 있던 Noto Sans KR 설정을 활성화하는 방식 선택.

## 검증

- `pnpm run build` 성공 (Turbo, 전체 정적 페이지 생성 확인)
- `pnpm run lint` 통과 (`--max-warnings 0`)
- `apps/blog`에서 `pnpm test` 통과 (22 suites / 94 tests)
- Playwright E2E는 CI에서 수행

Closes #95